### PR TITLE
Add CHTF_CURRENT_TERRAFORM_VERSION environment variable

### DIFF
--- a/chtf/chtf.sh
+++ b/chtf/chtf.sh
@@ -51,6 +51,7 @@ chtf_use() {
     [[ -n "$CHTF_CURRENT" ]] && chtf_reset
 
     export CHTF_CURRENT="$tf_path"
+    export CHTF_CURRENT_TERRAFORM_VERSION="$1"
     export PATH="$CHTF_CURRENT:$PATH"
 }
 


### PR DESCRIPTION
Adds CHTF_CURRENT_TERRAFORM_VERSION environment variable to easily determine which version is currently active. Handy with Powerline or similar tools.
