### PR TITLE
Introducing squiggly heredoc

### DIFF
--- a/Formula/chtf.rb
+++ b/Formula/chtf.rb
@@ -10,7 +10,7 @@ class Chtf < Formula
     share.install 'chtf'
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to the ~/.bashrc or ~/.zshrc file:
 
         # Source chtf


### PR DESCRIPTION
Ruby 2.2 is getting new to its EOL (scheduled for 2018-03-31) and as a result, homebrew is starting to issue warnings as pointed out by https://github.com/Yleisradio/homebrew-terraforms/issues/19
Squiggly heredoc (introduced in Ruby 2.3) offers easy replacement.

Fixes: #19 