### PR TITLE
add zsh hook to call chtf on chpwd

### DIFF
--- a/etc/chtf-on-chpwd.zsh
+++ b/etc/chtf-on-chpwd.zsh
@@ -1,0 +1,11 @@
+# change terraform version on cding into dir, if it has a .tf_version file. Otherwise, reset the terraform state.
+chtf-on-chpwd() {
+    if [[ -f ./.tf_version ]]; then
+        local tf_ver=$(cat ./.tf_version)
+        chtf $tf_ver
+    elif [[ ! -z "$CHTF_CURRENT" ]]; then
+        _chtf_reset
+    fi
+
+}
+chpwd_functions=(${chpwd_functions[@]} "chtf-on-chpwd")


### PR DESCRIPTION
For my use case I have to be sure I'm using the right terraform for the project I'm in.

This zsh chpwd hook looks for a `.tf_version` file in the directory we just entered, and invokes `chtf` with the contents of that file, which is expected to be something `chtf` can handle.

If the file isn't there, `_chtf_reset is called`. In my case, since I have no system terraform, this amounts to preventing me from calling terraform unless I know what version I want. I believe this is the safest thing to do, but I'm open to alternatives.

I don't know how to do this for bash or fish, but would be happy to add it with some guidance.

Other neat todos:
scan the directory tree for a hierarchy, so we can .tf_version at the terraform root, and not have to place one in each subfolder. Useful for things like

```bash
ls -a
. .. .tf_version alpha int prod

```
