### PR TITLE
Prepare support for darwin/arm64 architecture

### DIFF
--- a/Casks/terraform-0.1.0.rb
+++ b/Casks/terraform-0.1.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.1.0' do
-  version '0.1.0'
-  sha256 '309aed0ed61586e2682f58b77781f8e9805745a5edd1aebcddf883c9f624a0b9'
+cask "terraform-0.1.0" do
+  version "0.1.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.1.0/terraform_0.1.0_darwin_amd64.zip"
+    sha256 "309aed0ed61586e2682f58b77781f8e9805745a5edd1aebcddf883c9f624a0b9"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.1.1.rb
+++ b/Casks/terraform-0.1.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.1.1' do
-  version '0.1.1'
-  sha256 '1387eca09fcad8571f02d2f34b79d7cff5f420da8cc52e9b0841696461c99b38'
+cask "terraform-0.1.1" do
+  version "0.1.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.1.1/terraform_0.1.1_darwin_amd64.zip"
+    sha256 "1387eca09fcad8571f02d2f34b79d7cff5f420da8cc52e9b0841696461c99b38"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.10.0-beta1.rb
+++ b/Casks/terraform-0.10.0-beta1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.10.0-beta1' do
-  version '0.10.0-beta1'
-  sha256 '8170d52bd55bd80744aacd96ae8d87b39e29ed3d2d2853c9cb66ca62b5e295c6'
+cask "terraform-0.10.0-beta1" do
+  version "0.10.0-beta1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.10.0-beta1/terraform_0.10.0-beta1_darwin_amd64.zip"
+    sha256 "8170d52bd55bd80744aacd96ae8d87b39e29ed3d2d2853c9cb66ca62b5e295c6"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.10.0-beta2.rb
+++ b/Casks/terraform-0.10.0-beta2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.10.0-beta2' do
-  version '0.10.0-beta2'
-  sha256 '6138b4177e392e759bebc378cfe3a8dbbab6eae43214269464a005597aed85c6'
+cask "terraform-0.10.0-beta2" do
+  version "0.10.0-beta2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.10.0-beta2/terraform_0.10.0-beta2_darwin_amd64.zip"
+    sha256 "6138b4177e392e759bebc378cfe3a8dbbab6eae43214269464a005597aed85c6"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.10.0-rc1.rb
+++ b/Casks/terraform-0.10.0-rc1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.10.0-rc1' do
-  version '0.10.0-rc1'
-  sha256 'cb8b8c7abc291467bd432cbadb993b6972538c0d438cd6933d29c5c0702574d2'
+cask "terraform-0.10.0-rc1" do
+  version "0.10.0-rc1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.10.0-rc1/terraform_0.10.0-rc1_darwin_amd64.zip"
+    sha256 "cb8b8c7abc291467bd432cbadb993b6972538c0d438cd6933d29c5c0702574d2"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.10.0.rb
+++ b/Casks/terraform-0.10.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.10.0' do
-  version '0.10.0'
-  sha256 '1584dc21ad5ac1dc0d9a2876542a85d092778d00a0622622c28f8740abadddb9'
+cask "terraform-0.10.0" do
+  version "0.10.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.10.0/terraform_0.10.0_darwin_amd64.zip"
+    sha256 "1584dc21ad5ac1dc0d9a2876542a85d092778d00a0622622c28f8740abadddb9"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.10.1.rb
+++ b/Casks/terraform-0.10.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.10.1' do
-  version '0.10.1'
-  sha256 '5aae5125140b6cb39532360bd725fd33a9224b8358140291ff1d34a086dd646b'
+cask "terraform-0.10.1" do
+  version "0.10.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.10.1/terraform_0.10.1_darwin_amd64.zip"
+    sha256 "5aae5125140b6cb39532360bd725fd33a9224b8358140291ff1d34a086dd646b"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.10.2.rb
+++ b/Casks/terraform-0.10.2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.10.2' do
-  version '0.10.2'
-  sha256 '1ad6bad0349a3bcda8264746a3db0a39875c2cd93e3418393cc082bbb4812541'
+cask "terraform-0.10.2" do
+  version "0.10.2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.10.2/terraform_0.10.2_darwin_amd64.zip"
+    sha256 "1ad6bad0349a3bcda8264746a3db0a39875c2cd93e3418393cc082bbb4812541"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.10.3.rb
+++ b/Casks/terraform-0.10.3.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.10.3' do
-  version '0.10.3'
-  sha256 '6d7c51b8b8eee81b07c6b594077e0af95be518ed88b312bd3989c37b2924c2e6'
+cask "terraform-0.10.3" do
+  version "0.10.3"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.10.3/terraform_0.10.3_darwin_amd64.zip"
+    sha256 "6d7c51b8b8eee81b07c6b594077e0af95be518ed88b312bd3989c37b2924c2e6"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.10.4.rb
+++ b/Casks/terraform-0.10.4.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.10.4' do
-  version '0.10.4'
-  sha256 '70885c572f7bc54361c77d4839303210579db5875636711f621f6763574c1237'
+cask "terraform-0.10.4" do
+  version "0.10.4"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.10.4/terraform_0.10.4_darwin_amd64.zip"
+    sha256 "70885c572f7bc54361c77d4839303210579db5875636711f621f6763574c1237"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.10.5.rb
+++ b/Casks/terraform-0.10.5.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.10.5' do
-  version '0.10.5'
-  sha256 'd39ce30b7aa77834d3000173d95df476c0fcfea8114825d8276c38277d3a7436'
+cask "terraform-0.10.5" do
+  version "0.10.5"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.10.5/terraform_0.10.5_darwin_amd64.zip"
+    sha256 "d39ce30b7aa77834d3000173d95df476c0fcfea8114825d8276c38277d3a7436"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.10.6.rb
+++ b/Casks/terraform-0.10.6.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.10.6' do
-  version '0.10.6'
-  sha256 'a37f190cfcac21fa2343ec7e3112137d27fb9286c9f5c128547c6221502442c9'
+cask "terraform-0.10.6" do
+  version "0.10.6"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.10.6/terraform_0.10.6_darwin_amd64.zip"
+    sha256 "a37f190cfcac21fa2343ec7e3112137d27fb9286c9f5c128547c6221502442c9"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.10.7.rb
+++ b/Casks/terraform-0.10.7.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.10.7' do
-  version '0.10.7'
-  sha256 '60924d17e40be4b055629719a1f633736cca70c4506b8f7e32fa17e0d6e57477'
+cask "terraform-0.10.7" do
+  version "0.10.7"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.10.7/terraform_0.10.7_darwin_amd64.zip"
+    sha256 "60924d17e40be4b055629719a1f633736cca70c4506b8f7e32fa17e0d6e57477"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.10.8.rb
+++ b/Casks/terraform-0.10.8.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.10.8' do
-  version '0.10.8'
-  sha256 '3f05acdf0a9e04ba7e3bda18521feb0b310462dcce62c454854a40519b1695ed'
+cask "terraform-0.10.8" do
+  version "0.10.8"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_darwin_amd64.zip"
+    sha256 "3f05acdf0a9e04ba7e3bda18521feb0b310462dcce62c454854a40519b1695ed"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.0-beta1.rb
+++ b/Casks/terraform-0.11.0-beta1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.0-beta1' do
-  version '0.11.0-beta1'
-  sha256 '5a8f9118bf99285aa41c60b150fb628ec6a1bc49293663fd2255eedc5934f379'
+cask "terraform-0.11.0-beta1" do
+  version "0.11.0-beta1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.0-beta1/terraform_0.11.0-beta1_darwin_amd64.zip"
+    sha256 "5a8f9118bf99285aa41c60b150fb628ec6a1bc49293663fd2255eedc5934f379"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.0-rc1.rb
+++ b/Casks/terraform-0.11.0-rc1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.0-rc1' do
-  version '0.11.0-rc1'
-  sha256 'c7bbc03a40c089077e77befb3405c3fdf456f46e7b3bdafc50e48bfcc6f7b5a5'
+cask "terraform-0.11.0-rc1" do
+  version "0.11.0-rc1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.0-rc1/terraform_0.11.0-rc1_darwin_amd64.zip"
+    sha256 "c7bbc03a40c089077e77befb3405c3fdf456f46e7b3bdafc50e48bfcc6f7b5a5"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.0.rb
+++ b/Casks/terraform-0.11.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.0' do
-  version '0.11.0'
-  sha256 '0d5f7ffcfd34fe58ed25fe48650f1c9ac1d9e15983af43deaeffc6d0a88ba346'
+cask "terraform-0.11.0" do
+  version "0.11.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_darwin_amd64.zip"
+    sha256 "0d5f7ffcfd34fe58ed25fe48650f1c9ac1d9e15983af43deaeffc6d0a88ba346"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.1.rb
+++ b/Casks/terraform-0.11.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.1' do
-  version '0.11.1'
-  sha256 'f5e04d3886e9a427490d1aa857a61b5a87d08dc26fb8637e3eaa72b30562c330'
+cask "terraform-0.11.1" do
+  version "0.11.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.1/terraform_0.11.1_darwin_amd64.zip"
+    sha256 "f5e04d3886e9a427490d1aa857a61b5a87d08dc26fb8637e3eaa72b30562c330"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.10.rb
+++ b/Casks/terraform-0.11.10.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.10' do
-  version '0.11.10'
-  sha256 'cb5ae1fa5bed45d81d79d427cd1dd84ed7c04f712c72b420003e28f522a77a78'
+cask "terraform-0.11.10" do
+  version "0.11.10"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_darwin_amd64.zip"
+    sha256 "cb5ae1fa5bed45d81d79d427cd1dd84ed7c04f712c72b420003e28f522a77a78"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.11.rb
+++ b/Casks/terraform-0.11.11.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.11' do
-  version '0.11.11'
-  sha256 '6b6e8253b678554c67d717c42209fd857bfe64a1461763c05d3d1d85c6f618d3'
+cask "terraform-0.11.11" do
+  version "0.11.11"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_darwin_amd64.zip"
+    sha256 "6b6e8253b678554c67d717c42209fd857bfe64a1461763c05d3d1d85c6f618d3"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.12-beta1.rb
+++ b/Casks/terraform-0.11.12-beta1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.12-beta1' do
-  version '0.11.12-beta1'
-  sha256 '8c1f4f975bf4bba6725e6e1cbc69c4a7764a3fb6dc6aebf2e718456eed6405a9'
+cask "terraform-0.11.12-beta1" do
+  version "0.11.12-beta1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.12-beta1/terraform_0.11.12-beta1_darwin_amd64.zip"
+    sha256 "8c1f4f975bf4bba6725e6e1cbc69c4a7764a3fb6dc6aebf2e718456eed6405a9"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.12.rb
+++ b/Casks/terraform-0.11.12.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.12' do
-  version '0.11.12'
-  sha256 '316fa873b26463f3e015db11dba00eab1839338f930f1352dbab2d0bcd0828a5'
+cask "terraform-0.11.12" do
+  version "0.11.12"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.12/terraform_0.11.12_darwin_amd64.zip"
+    sha256 "316fa873b26463f3e015db11dba00eab1839338f930f1352dbab2d0bcd0828a5"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.13.rb
+++ b/Casks/terraform-0.11.13.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.13' do
-  version '0.11.13'
-  sha256 'e9988443da39e5d81a5f7f1b6a5d97b25e2a1151d9be76cdc2e380df97e57856'
+cask "terraform-0.11.13" do
+  version "0.11.13"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_darwin_amd64.zip"
+    sha256 "e9988443da39e5d81a5f7f1b6a5d97b25e2a1151d9be76cdc2e380df97e57856"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.14.rb
+++ b/Casks/terraform-0.11.14.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.14' do
-  version '0.11.14'
-  sha256 '829bdba148afbd61eab4aafbc6087838f0333d8876624fe2ebc023920cfc2ad5'
+cask "terraform-0.11.14" do
+  version "0.11.14"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_darwin_amd64.zip"
+    sha256 "829bdba148afbd61eab4aafbc6087838f0333d8876624fe2ebc023920cfc2ad5"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.15-oci.rb
+++ b/Casks/terraform-0.11.15-oci.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.15-oci' do
-  version '0.11.15-oci'
-  sha256 '4ac1b0a1a7ee9e04165ce035300eddf9119124046d63fc4bfeffcc88fc6365bb'
+cask "terraform-0.11.15-oci" do
+  version "0.11.15-oci"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.15-oci/terraform_0.11.15-oci_darwin_amd64.zip"
+    sha256 "4ac1b0a1a7ee9e04165ce035300eddf9119124046d63fc4bfeffcc88fc6365bb"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.2.rb
+++ b/Casks/terraform-0.11.2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.2' do
-  version '0.11.2'
-  sha256 'ff5c3c4bcfe84e011b96a2232704b2db196383ce5d4a32e47956c883ddc94bac'
+cask "terraform-0.11.2" do
+  version "0.11.2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.2/terraform_0.11.2_darwin_amd64.zip"
+    sha256 "ff5c3c4bcfe84e011b96a2232704b2db196383ce5d4a32e47956c883ddc94bac"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.3.rb
+++ b/Casks/terraform-0.11.3.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.3' do
-  version '0.11.3'
-  sha256 '183078bf230e517e6f41e47d6e7d3b61093c6bb5a2b85958c01a4cf3949b7c14'
+cask "terraform-0.11.3" do
+  version "0.11.3"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.3/terraform_0.11.3_darwin_amd64.zip"
+    sha256 "183078bf230e517e6f41e47d6e7d3b61093c6bb5a2b85958c01a4cf3949b7c14"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.4.rb
+++ b/Casks/terraform-0.11.4.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.4' do
-  version '0.11.4'
-  sha256 'c328b8d60840b96641f519deb85601cb1f2cce458c7bdb7786712471234ac0c5'
+cask "terraform-0.11.4" do
+  version "0.11.4"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.4/terraform_0.11.4_darwin_amd64.zip"
+    sha256 "c328b8d60840b96641f519deb85601cb1f2cce458c7bdb7786712471234ac0c5"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.5.rb
+++ b/Casks/terraform-0.11.5.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.5' do
-  version '0.11.5'
-  sha256 '0af78baf9b1a249544cc0b17d6b7abb32cc513a554d1f7dcc85c873e2af93586'
+cask "terraform-0.11.5" do
+  version "0.11.5"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.5/terraform_0.11.5_darwin_amd64.zip"
+    sha256 "0af78baf9b1a249544cc0b17d6b7abb32cc513a554d1f7dcc85c873e2af93586"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.6.rb
+++ b/Casks/terraform-0.11.6.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.6' do
-  version '0.11.6'
-  sha256 'edbdde7ca769a5c7ca1c048bd5729b1f70d556b4ee61287dff5057660bc1f64d'
+cask "terraform-0.11.6" do
+  version "0.11.6"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.6/terraform_0.11.6_darwin_amd64.zip"
+    sha256 "edbdde7ca769a5c7ca1c048bd5729b1f70d556b4ee61287dff5057660bc1f64d"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.7.rb
+++ b/Casks/terraform-0.11.7.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.7' do
-  version '0.11.7'
-  sha256 '6514a8fe5a344c5b8819c7f32745cd571f58092ffc9bbe9ea3639799b97ced5f'
+cask "terraform-0.11.7" do
+  version "0.11.7"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_darwin_amd64.zip"
+    sha256 "6514a8fe5a344c5b8819c7f32745cd571f58092ffc9bbe9ea3639799b97ced5f"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.8.rb
+++ b/Casks/terraform-0.11.8.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.8' do
-  version '0.11.8'
-  sha256 '98c168b06e8b4058c66e044e3744d49956ce7bc3664dc1679a33f8fffc84564d'
+cask "terraform-0.11.8" do
+  version "0.11.8"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_darwin_amd64.zip"
+    sha256 "98c168b06e8b4058c66e044e3744d49956ce7bc3664dc1679a33f8fffc84564d"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.9-beta1.rb
+++ b/Casks/terraform-0.11.9-beta1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.9-beta1' do
-  version '0.11.9-beta1'
-  sha256 'a95ac475acd068a876a1068fa90cb2e9370e1c28e8c7fc57b7db016629b533be'
+cask "terraform-0.11.9-beta1" do
+  version "0.11.9-beta1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.9-beta1/terraform_0.11.9-beta1_darwin_amd64.zip"
+    sha256 "a95ac475acd068a876a1068fa90cb2e9370e1c28e8c7fc57b7db016629b533be"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.11.9.rb
+++ b/Casks/terraform-0.11.9.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.11.9' do
-  version '0.11.9'
-  sha256 '1b5a0c916f547c396959b8c303f3bfa7a2e936c78f002bf42e532c9254fd6d75'
+cask "terraform-0.11.9" do
+  version "0.11.9"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.11.9/terraform_0.11.9_darwin_amd64.zip"
+    sha256 "1b5a0c916f547c396959b8c303f3bfa7a2e936c78f002bf42e532c9254fd6d75"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.0-alpha1.rb
+++ b/Casks/terraform-0.12.0-alpha1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.0-alpha1' do
-  version '0.12.0-alpha1'
-  sha256 '2797b82e22c5557da604b6b727cb8112844a92c81b16840980a43ed78d9e0512'
+cask "terraform-0.12.0-alpha1" do
+  version "0.12.0-alpha1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.0-alpha1/terraform_0.12.0-alpha1_darwin_amd64.zip"
+    sha256 "2797b82e22c5557da604b6b727cb8112844a92c81b16840980a43ed78d9e0512"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.0-alpha2.rb
+++ b/Casks/terraform-0.12.0-alpha2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.0-alpha2' do
-  version '0.12.0-alpha2'
-  sha256 '859fa4459f8cc8b4cda026b71cd7c8011fafc765e570fbdf3abe9fbcad44d59c'
+cask "terraform-0.12.0-alpha2" do
+  version "0.12.0-alpha2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.0-alpha2/terraform_0.12.0-alpha2_darwin_amd64.zip"
+    sha256 "859fa4459f8cc8b4cda026b71cd7c8011fafc765e570fbdf3abe9fbcad44d59c"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.0-alpha3.rb
+++ b/Casks/terraform-0.12.0-alpha3.rb
@@ -1,10 +1,15 @@
-cask 'terraform-0.12.0-alpha3' do
-  version '0.12.0-alpha3'
-  sha256 '027d468deb4898036b10aa0654717da6efca315aa636a2d156cb87404d89daef'
+cask "terraform-0.12.0-alpha3" do
+  version "0.12.0-alpha3"
 
-  # XXX: Strange URL for 0.12.0-alpha3
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_terraform_#{version}_darwin_amd64.zip"
+  name "Terraform"
+  homepage "https://www.terraform.io/"
 
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  case Hardware::CPU.arch
+  when :x86_64
+    # XXX: Strange URL for 0.12.0-alpha4
+    url "https://releases.hashicorp.com/terraform/0.12.0-alpha4/terraform_0.12.0-alpha4_terraform_0.12.0-alpha4_darwin_amd64.zip"
+    sha256 "ff742e857fe37e76747f099cf99f043c36d408c62cefba6a700e3c9c118e0690"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.0-alpha4.rb
+++ b/Casks/terraform-0.12.0-alpha4.rb
@@ -1,9 +1,15 @@
-cask 'terraform-0.12.0-alpha4' do
-  version '0.12.0-alpha4'
-  sha256 'ff742e857fe37e76747f099cf99f043c36d408c62cefba6a700e3c9c118e0690'
+cask "terraform-0.12.0-alpha4" do
+  version "0.12.0-alpha4"
 
-  # XXX: Strange URL for 0.12.0-alpha4
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    # XXX: Strange URL for 0.12.0-alpha3
+    url "https://releases.hashicorp.com/terraform/0.12.0-alpha3/terraform_0.12.0-alpha3_terraform_0.12.0-alpha3_darwin_amd64.zip"
+    sha256 "027d468deb4898036b10aa0654717da6efca315aa636a2d156cb87404d89daef"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.0-beta1.rb
+++ b/Casks/terraform-0.12.0-beta1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.0-beta1' do
-  version '0.12.0-beta1'
-  sha256 '2da57018c25ada511b7131d85257f534030eddf23b347663af4c4ca89d3d9220'
+cask "terraform-0.12.0-beta1" do
+  version "0.12.0-beta1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.0-beta1/terraform_0.12.0-beta1_darwin_amd64.zip"
+    sha256 "2da57018c25ada511b7131d85257f534030eddf23b347663af4c4ca89d3d9220"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.0-beta2.rb
+++ b/Casks/terraform-0.12.0-beta2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.0-beta2' do
-  version '0.12.0-beta2'
-  sha256 '6be99d150329e55ae636e40500e96a6243a6a00d74126eef9fdb47f17a1070d7'
+cask "terraform-0.12.0-beta2" do
+  version "0.12.0-beta2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.0-beta2/terraform_0.12.0-beta2_darwin_amd64.zip"
+    sha256 "6be99d150329e55ae636e40500e96a6243a6a00d74126eef9fdb47f17a1070d7"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.0-rc1.rb
+++ b/Casks/terraform-0.12.0-rc1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.0-rc1' do
-  version '0.12.0-rc1'
-  sha256 'cb10093fe8b14771047314b547c7710e363199c40e129bb7e3b4886e3f3b3ca6'
+cask "terraform-0.12.0-rc1" do
+  version "0.12.0-rc1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.0-rc1/terraform_0.12.0-rc1_darwin_amd64.zip"
+    sha256 "cb10093fe8b14771047314b547c7710e363199c40e129bb7e3b4886e3f3b3ca6"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.0.rb
+++ b/Casks/terraform-0.12.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.0' do
-  version '0.12.0'
-  sha256 '9dbee9dea660ea64352f8ddf2539e60d1c414210e9c4a29c8585926fef366be1'
+cask "terraform-0.12.0" do
+  version "0.12.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.0/terraform_0.12.0_darwin_amd64.zip"
+    sha256 "9dbee9dea660ea64352f8ddf2539e60d1c414210e9c4a29c8585926fef366be1"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.1.rb
+++ b/Casks/terraform-0.12.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.1' do
-  version '0.12.1'
-  sha256 '3c5b0aa8f3acf477a5d5ae997174bd16d49bb0789915b5a40a6deb39692a5c8d'
+cask "terraform-0.12.1" do
+  version "0.12.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.1/terraform_0.12.1_darwin_amd64.zip"
+    sha256 "3c5b0aa8f3acf477a5d5ae997174bd16d49bb0789915b5a40a6deb39692a5c8d"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.10.rb
+++ b/Casks/terraform-0.12.10.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.10' do
-  version '0.12.10'
-  sha256 'd97db2217c6050926eedf517b7b0427b1b5f1bda989742cfd33d8fe56c95bb05'
+cask "terraform-0.12.10" do
+  version "0.12.10"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.10/terraform_0.12.10_darwin_amd64.zip"
+    sha256 "d97db2217c6050926eedf517b7b0427b1b5f1bda989742cfd33d8fe56c95bb05"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.11.rb
+++ b/Casks/terraform-0.12.11.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.11' do
-  version '0.12.11'
-  sha256 'e1ddcd5f40d3e9b2758d8bc4858117f5df94169fec16495dada96d3ab358ff34'
+cask "terraform-0.12.11" do
+  version "0.12.11"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.11/terraform_0.12.11_darwin_amd64.zip"
+    sha256 "e1ddcd5f40d3e9b2758d8bc4858117f5df94169fec16495dada96d3ab358ff34"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.12.rb
+++ b/Casks/terraform-0.12.12.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.12' do
-  version '0.12.12'
-  sha256 '51507dedba7fcc2638c5c2c40206ec604155e2d3067a132b618f4e99ea9f1db9'
+cask "terraform-0.12.12" do
+  version "0.12.12"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.12/terraform_0.12.12_darwin_amd64.zip"
+    sha256 "51507dedba7fcc2638c5c2c40206ec604155e2d3067a132b618f4e99ea9f1db9"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.13.rb
+++ b/Casks/terraform-0.12.13.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.13' do
-  version '0.12.13'
-  sha256 '744dfa3c4f566cabddf2fa6b3b19fab06d512f3c654c09906e8acaaaa2388cfb'
+cask "terraform-0.12.13" do
+  version "0.12.13"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.13/terraform_0.12.13_darwin_amd64.zip"
+    sha256 "744dfa3c4f566cabddf2fa6b3b19fab06d512f3c654c09906e8acaaaa2388cfb"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.14.rb
+++ b/Casks/terraform-0.12.14.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.14' do
-  version '0.12.14'
-  sha256 '2a4538ccf212865cb2c275dc079926f409b3809cb589638f560d5ab389babe00'
+cask "terraform-0.12.14" do
+  version "0.12.14"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.14/terraform_0.12.14_darwin_amd64.zip"
+    sha256 "2a4538ccf212865cb2c275dc079926f409b3809cb589638f560d5ab389babe00"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.15.rb
+++ b/Casks/terraform-0.12.15.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.15' do
-  version '0.12.15'
-  sha256 'c1ec56b36e8395a454b7d0ba421aa42c54d2f91c913893447d20aecf1437623f'
+cask "terraform-0.12.15" do
+  version "0.12.15"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.15/terraform_0.12.15_darwin_amd64.zip"
+    sha256 "c1ec56b36e8395a454b7d0ba421aa42c54d2f91c913893447d20aecf1437623f"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.16.rb
+++ b/Casks/terraform-0.12.16.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.16' do
-  version '0.12.16'
-  sha256 '02f893e326b25705aff2594d9f28a4a0c9d50f44a0e7e7129633f02c11a2e47d'
+cask "terraform-0.12.16" do
+  version "0.12.16"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.16/terraform_0.12.16_darwin_amd64.zip"
+    sha256 "02f893e326b25705aff2594d9f28a4a0c9d50f44a0e7e7129633f02c11a2e47d"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.17.rb
+++ b/Casks/terraform-0.12.17.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.17' do
-  version '0.12.17'
-  sha256 'b0ab66e77bac3abcd8b36afa5e567ab4fef103fc21c4a223c954c4ea60f5d244'
+cask "terraform-0.12.17" do
+  version "0.12.17"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.17/terraform_0.12.17_darwin_amd64.zip"
+    sha256 "b0ab66e77bac3abcd8b36afa5e567ab4fef103fc21c4a223c954c4ea60f5d244"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.18.rb
+++ b/Casks/terraform-0.12.18.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.18' do
-  version '0.12.18'
-  sha256 'dd6983cfe0d0922de51e019a80db2a270e8a2636b9f05b49bf7dcbfe7bd90ea9'
+cask "terraform-0.12.18" do
+  version "0.12.18"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.18/terraform_0.12.18_darwin_amd64.zip"
+    sha256 "dd6983cfe0d0922de51e019a80db2a270e8a2636b9f05b49bf7dcbfe7bd90ea9"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.19.rb
+++ b/Casks/terraform-0.12.19.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.19' do
-  version '0.12.19'
-  sha256 '5238fe45d051cac90f0fc0701796c5244ef88218d0fe4eceec31cee43899a434'
+cask "terraform-0.12.19" do
+  version "0.12.19"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.19/terraform_0.12.19_darwin_amd64.zip"
+    sha256 "5238fe45d051cac90f0fc0701796c5244ef88218d0fe4eceec31cee43899a434"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.2.rb
+++ b/Casks/terraform-0.12.2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.2' do
-  version '0.12.2'
-  sha256 'f0cc23bc6ec1a5adc4043108ff5c79c2bddcdc70b056bd207defca1ae386d477'
+cask "terraform-0.12.2" do
+  version "0.12.2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.2/terraform_0.12.2_darwin_amd64.zip"
+    sha256 "f0cc23bc6ec1a5adc4043108ff5c79c2bddcdc70b056bd207defca1ae386d477"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.20.rb
+++ b/Casks/terraform-0.12.20.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.20' do
-  version '0.12.20'
-  sha256 '9e2ef974618402b70d4491f50701621e1a9f1cb32862592f0af3fee12324d378'
+cask "terraform-0.12.20" do
+  version "0.12.20"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.20/terraform_0.12.20_darwin_amd64.zip"
+    sha256 "9e2ef974618402b70d4491f50701621e1a9f1cb32862592f0af3fee12324d378"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.21.rb
+++ b/Casks/terraform-0.12.21.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.21' do
-  version '0.12.21'
-  sha256 'f89b620e59439fccc80950bbcbd37a069101cbef7029029a12227eee831e463f'
+cask "terraform-0.12.21" do
+  version "0.12.21"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.21/terraform_0.12.21_darwin_amd64.zip"
+    sha256 "f89b620e59439fccc80950bbcbd37a069101cbef7029029a12227eee831e463f"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.22.rb
+++ b/Casks/terraform-0.12.22.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.22' do
-  version '0.12.22'
-  sha256 '13d0dd4a4c7cb5dea403c1a02dd9200ff9de086e8ddd832ffea2219c59d33fe1'
+cask "terraform-0.12.22" do
+  version "0.12.22"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.22/terraform_0.12.22_darwin_amd64.zip"
+    sha256 "13d0dd4a4c7cb5dea403c1a02dd9200ff9de086e8ddd832ffea2219c59d33fe1"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.23.rb
+++ b/Casks/terraform-0.12.23.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.23' do
-  version '0.12.23'
-  sha256 'ca1a0bc58b4e482d0bdcaee95d002f4901094935fd4b184f57563a5c34fd18d9'
+cask "terraform-0.12.23" do
+  version "0.12.23"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.23/terraform_0.12.23_darwin_amd64.zip"
+    sha256 "ca1a0bc58b4e482d0bdcaee95d002f4901094935fd4b184f57563a5c34fd18d9"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.24.rb
+++ b/Casks/terraform-0.12.24.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.24' do
-  version '0.12.24'
-  sha256 '72482000a5e25c33e88e95d70208304acfd09bf855a7ede110da032089d13b4f'
+cask "terraform-0.12.24" do
+  version "0.12.24"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_darwin_amd64.zip"
+    sha256 "72482000a5e25c33e88e95d70208304acfd09bf855a7ede110da032089d13b4f"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.25.rb
+++ b/Casks/terraform-0.12.25.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.25' do
-  version '0.12.25'
-  sha256 '179fc99ccea5ed3617e9e7026dcfa59a5916ea91162afd7a2acd8350906a0d68'
+cask "terraform-0.12.25" do
+  version "0.12.25"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.25/terraform_0.12.25_darwin_amd64.zip"
+    sha256 "179fc99ccea5ed3617e9e7026dcfa59a5916ea91162afd7a2acd8350906a0d68"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.26.rb
+++ b/Casks/terraform-0.12.26.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.26' do
-  version '0.12.26'
-  sha256 '79fb293324012bc981006e1527267987666dd80cff80b11f93fb0ab2e321c450'
+cask "terraform-0.12.26" do
+  version "0.12.26"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.26/terraform_0.12.26_darwin_amd64.zip"
+    sha256 "79fb293324012bc981006e1527267987666dd80cff80b11f93fb0ab2e321c450"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.27.rb
+++ b/Casks/terraform-0.12.27.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.27' do
-  version '0.12.27'
-  sha256 '3941e8b3f81257e54997cd717cec5dfbf3a254643a47e3ac8c687f26c0b8814f'
+cask "terraform-0.12.27" do
+  version "0.12.27"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.27/terraform_0.12.27_darwin_amd64.zip"
+    sha256 "3941e8b3f81257e54997cd717cec5dfbf3a254643a47e3ac8c687f26c0b8814f"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.28.rb
+++ b/Casks/terraform-0.12.28.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.28' do
-  version '0.12.28'
-  sha256 '893050bcfc5e7445acd3a30f1500227b989b29cbd958ca64a8233589194a198d'
+cask "terraform-0.12.28" do
+  version "0.12.28"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.28/terraform_0.12.28_darwin_amd64.zip"
+    sha256 "893050bcfc5e7445acd3a30f1500227b989b29cbd958ca64a8233589194a198d"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.29.rb
+++ b/Casks/terraform-0.12.29.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.29' do
-  version '0.12.29'
-  sha256 'fdcda98ff7b7e65832248f64ef6c2922e05036de25d40c5cdcd732c5117150aa'
+cask "terraform-0.12.29" do
+  version "0.12.29"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_darwin_amd64.zip"
+    sha256 "fdcda98ff7b7e65832248f64ef6c2922e05036de25d40c5cdcd732c5117150aa"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.3.rb
+++ b/Casks/terraform-0.12.3.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.3' do
-  version '0.12.3'
-  sha256 'f0e09af8ce413ec9a949c00ea6645cd8169a03412e545a3375adf91c3ad8c7ad'
+cask "terraform-0.12.3" do
+  version "0.12.3"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.3/terraform_0.12.3_darwin_amd64.zip"
+    sha256 "f0e09af8ce413ec9a949c00ea6645cd8169a03412e545a3375adf91c3ad8c7ad"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.30.rb
+++ b/Casks/terraform-0.12.30.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.30' do
-  version '0.12.30'
-  sha256 'f107ed316be1b86a63df4e47a1fb8ab8c9ffdbbc606dcdf90043f91bdb21826d'
+cask "terraform-0.12.30" do
+  version "0.12.30"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.30/terraform_0.12.30_darwin_amd64.zip"
+    sha256 "f107ed316be1b86a63df4e47a1fb8ab8c9ffdbbc606dcdf90043f91bdb21826d"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.4.rb
+++ b/Casks/terraform-0.12.4.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.4' do
-  version '0.12.4'
-  sha256 'e19691d775849888a0695a07e52a884dc617ca2100759eca5bbe4d0f428a7bc3'
+cask "terraform-0.12.4" do
+  version "0.12.4"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.4/terraform_0.12.4_darwin_amd64.zip"
+    sha256 "e19691d775849888a0695a07e52a884dc617ca2100759eca5bbe4d0f428a7bc3"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.5.rb
+++ b/Casks/terraform-0.12.5.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.5' do
-  version '0.12.5'
-  sha256 'e0afcf6f6401e9eaab0be588b55b5226549253854acc1d0cde331b8ca54727e0'
+cask "terraform-0.12.5" do
+  version "0.12.5"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.5/terraform_0.12.5_darwin_amd64.zip"
+    sha256 "e0afcf6f6401e9eaab0be588b55b5226549253854acc1d0cde331b8ca54727e0"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.6.rb
+++ b/Casks/terraform-0.12.6.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.6' do
-  version '0.12.6'
-  sha256 '7168dfa057d9aed7ea3f111d87294f263e341c8b848e776bc13d169ddf2926c7'
+cask "terraform-0.12.6" do
+  version "0.12.6"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.6/terraform_0.12.6_darwin_amd64.zip"
+    sha256 "7168dfa057d9aed7ea3f111d87294f263e341c8b848e776bc13d169ddf2926c7"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.7.rb
+++ b/Casks/terraform-0.12.7.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.7' do
-  version '0.12.7'
-  sha256 '5cb59cdc4a8c4ebdfc0b8715936110e707d869c59603d27020e33b2be2e50f21'
+cask "terraform-0.12.7" do
+  version "0.12.7"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_darwin_amd64.zip"
+    sha256 "5cb59cdc4a8c4ebdfc0b8715936110e707d869c59603d27020e33b2be2e50f21"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.8.rb
+++ b/Casks/terraform-0.12.8.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.8' do
-  version '0.12.8'
-  sha256 '2c2d9d435712f4be989738b7899917ced7c12ab05b8ddc14359ed4ddb1bc9375'
+cask "terraform-0.12.8" do
+  version "0.12.8"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.8/terraform_0.12.8_darwin_amd64.zip"
+    sha256 "2c2d9d435712f4be989738b7899917ced7c12ab05b8ddc14359ed4ddb1bc9375"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.12.9.rb
+++ b/Casks/terraform-0.12.9.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.12.9' do
-  version '0.12.9'
-  sha256 'dbb3c0ffb37a5e659e05b8c223a717f89ffda7761d23eaf596c31b9745557288'
+cask "terraform-0.12.9" do
+  version "0.12.9"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_darwin_amd64.zip"
+    sha256 "dbb3c0ffb37a5e659e05b8c223a717f89ffda7761d23eaf596c31b9745557288"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.13.0-beta1.rb
+++ b/Casks/terraform-0.13.0-beta1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.13.0-beta1' do
-  version '0.13.0-beta1'
-  sha256 'dfdc8ef005df19d7ec0fcb5f151e51b144233ca425c39dabf94c037e80780b05'
+cask "terraform-0.13.0-beta1" do
+  version "0.13.0-beta1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.13.0-beta1/terraform_0.13.0-beta1_darwin_amd64.zip"
+    sha256 "dfdc8ef005df19d7ec0fcb5f151e51b144233ca425c39dabf94c037e80780b05"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.13.0-beta2.rb
+++ b/Casks/terraform-0.13.0-beta2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.13.0-beta2' do
-  version '0.13.0-beta2'
-  sha256 '4729fa267c5be7f1d0c19a85d36e2b4577f303866fc25403650acb4243c2021f'
+cask "terraform-0.13.0-beta2" do
+  version "0.13.0-beta2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.13.0-beta2/terraform_0.13.0-beta2_darwin_amd64.zip"
+    sha256 "4729fa267c5be7f1d0c19a85d36e2b4577f303866fc25403650acb4243c2021f"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.13.0-beta3.rb
+++ b/Casks/terraform-0.13.0-beta3.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.13.0-beta3' do
-  version '0.13.0-beta3'
-  sha256 '8e49d45da847120ea1e162d0b3fcd6b322e8dff419c6cc5cb535a3041a650391'
+cask "terraform-0.13.0-beta3" do
+  version "0.13.0-beta3"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.13.0-beta3/terraform_0.13.0-beta3_darwin_amd64.zip"
+    sha256 "8e49d45da847120ea1e162d0b3fcd6b322e8dff419c6cc5cb535a3041a650391"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.13.0-rc1.rb
+++ b/Casks/terraform-0.13.0-rc1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.13.0-rc1' do
-  version '0.13.0-rc1'
-  sha256 'cf24555d0089947d690dbb4860bc7f4206da5b71092f150c4785185b2ed837cd'
+cask "terraform-0.13.0-rc1" do
+  version "0.13.0-rc1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.13.0-rc1/terraform_0.13.0-rc1_darwin_amd64.zip"
+    sha256 "cf24555d0089947d690dbb4860bc7f4206da5b71092f150c4785185b2ed837cd"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.13.0.rb
+++ b/Casks/terraform-0.13.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.13.0' do
-  version '0.13.0'
-  sha256 '080af0420732cd08941aa4c0d2b4693056b24366724faa11b107bf052f7de203'
+cask "terraform-0.13.0" do
+  version "0.13.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.13.0/terraform_0.13.0_darwin_amd64.zip"
+    sha256 "080af0420732cd08941aa4c0d2b4693056b24366724faa11b107bf052f7de203"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.13.1.rb
+++ b/Casks/terraform-0.13.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.13.1' do
-  version '0.13.1'
-  sha256 'fe5d1b6e22892c5dcc8b44d2a26ea1e29d90af6fcb1472f3881ca3c08c8a8084'
+cask "terraform-0.13.1" do
+  version "0.13.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.1_darwin_amd64.zip"
+    sha256 "fe5d1b6e22892c5dcc8b44d2a26ea1e29d90af6fcb1472f3881ca3c08c8a8084"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.13.2.rb
+++ b/Casks/terraform-0.13.2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.13.2' do
-  version '0.13.2'
-  sha256 '7af2f9c03e8687c87e7798178a2dac9a3061955eb19f0f69501475e017b8d8f6'
+cask "terraform-0.13.2" do
+  version "0.13.2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_darwin_amd64.zip"
+    sha256 "7af2f9c03e8687c87e7798178a2dac9a3061955eb19f0f69501475e017b8d8f6"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.13.3.rb
+++ b/Casks/terraform-0.13.3.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.13.3' do
-  version '0.13.3'
-  sha256 'ccbfd3af8732a47b6bd32c419e1a52e41eb8a39ff7437afffbef438b5c0f92c3'
+cask "terraform-0.13.3" do
+  version "0.13.3"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_darwin_amd64.zip"
+    sha256 "ccbfd3af8732a47b6bd32c419e1a52e41eb8a39ff7437afffbef438b5c0f92c3"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.13.4.rb
+++ b/Casks/terraform-0.13.4.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.13.4' do
-  version '0.13.4'
-  sha256 'd16d3094b0f9f56d7e05b4c09a923141a483f51e58613ae64507b0f7ba45bb34'
+cask "terraform-0.13.4" do
+  version "0.13.4"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.13.4/terraform_0.13.4_darwin_amd64.zip"
+    sha256 "d16d3094b0f9f56d7e05b4c09a923141a483f51e58613ae64507b0f7ba45bb34"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.13.5.rb
+++ b/Casks/terraform-0.13.5.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.13.5' do
-  version '0.13.5'
-  sha256 '03f7b636638c587c3b03a4b3d1d4cab77c872ad5f7e55405ddaf38dfb94e0e89'
+cask "terraform-0.13.5" do
+  version "0.13.5"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_darwin_amd64.zip"
+    sha256 "03f7b636638c587c3b03a4b3d1d4cab77c872ad5f7e55405ddaf38dfb94e0e89"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.13.6.rb
+++ b/Casks/terraform-0.13.6.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.13.6' do
-  version '0.13.6'
-  sha256 'cbb76aed9c01a8c0fbee4e3a10112ab7836440fa63d93414a1dc45ef59bc0ea2'
+cask "terraform-0.13.6" do
+  version "0.13.6"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.13.6/terraform_0.13.6_darwin_amd64.zip"
+    sha256 "cbb76aed9c01a8c0fbee4e3a10112ab7836440fa63d93414a1dc45ef59bc0ea2"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.0-alpha20200910.rb
+++ b/Casks/terraform-0.14.0-alpha20200910.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.0-alpha20200910' do
-  version '0.14.0-alpha20200910'
-  sha256 '2e65f929c74134f2a40ae1f092097c24159186e5ac58fbf19841a21b9f575893'
+cask "terraform-0.14.0-alpha20200910" do
+  version "0.14.0-alpha20200910"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.0-alpha20200910/terraform_0.14.0-alpha20200910_darwin_amd64.zip"
+    sha256 "2e65f929c74134f2a40ae1f092097c24159186e5ac58fbf19841a21b9f575893"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.0-alpha20200923.rb
+++ b/Casks/terraform-0.14.0-alpha20200923.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.0-alpha20200923' do
-  version '0.14.0-alpha20200923'
-  sha256 '7d7e888fdd28abfe00894f9055209b9eec785153641de98e6852aa071008d4ee'
+cask "terraform-0.14.0-alpha20200923" do
+  version "0.14.0-alpha20200923"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.0-alpha20200923/terraform_0.14.0-alpha20200923_darwin_amd64.zip"
+    sha256 "7d7e888fdd28abfe00894f9055209b9eec785153641de98e6852aa071008d4ee"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.0-alpha20201007.rb
+++ b/Casks/terraform-0.14.0-alpha20201007.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.0-alpha20201007' do
-  version '0.14.0-alpha20201007'
-  sha256 'f2689edb2dbe46fafbdf92062a37c695d398d5224756c57db62fae8097f54a0a'
+cask "terraform-0.14.0-alpha20201007" do
+  version "0.14.0-alpha20201007"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.0-alpha20201007/terraform_0.14.0-alpha20201007_darwin_amd64.zip"
+    sha256 "f2689edb2dbe46fafbdf92062a37c695d398d5224756c57db62fae8097f54a0a"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.0-beta1.rb
+++ b/Casks/terraform-0.14.0-beta1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.0-beta1' do
-  version '0.14.0-beta1'
-  sha256 '10c5c0969438f973a25cffcae3e567697822459da3ff177d707f3ae2d5100962'
+cask "terraform-0.14.0-beta1" do
+  version "0.14.0-beta1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.0-beta1/terraform_0.14.0-beta1_darwin_amd64.zip"
+    sha256 "10c5c0969438f973a25cffcae3e567697822459da3ff177d707f3ae2d5100962"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.0-beta2.rb
+++ b/Casks/terraform-0.14.0-beta2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.0-beta2' do
-  version '0.14.0-beta2'
-  sha256 'fc9c78035efa97c36b2abf590d562fe99ffb9d0fb3224c3b0fb6f80fff4d2754'
+cask "terraform-0.14.0-beta2" do
+  version "0.14.0-beta2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.0-beta2/terraform_0.14.0-beta2_darwin_amd64.zip"
+    sha256 "fc9c78035efa97c36b2abf590d562fe99ffb9d0fb3224c3b0fb6f80fff4d2754"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.0-rc1.rb
+++ b/Casks/terraform-0.14.0-rc1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.0-rc1' do
-  version '0.14.0-rc1'
-  sha256 '6fcb3898b33887fdd3c8f14cf92783a52bdab224164db972e65301f30baac3df'
+cask "terraform-0.14.0-rc1" do
+  version "0.14.0-rc1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.0-rc1/terraform_0.14.0-rc1_darwin_amd64.zip"
+    sha256 "6fcb3898b33887fdd3c8f14cf92783a52bdab224164db972e65301f30baac3df"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.0.rb
+++ b/Casks/terraform-0.14.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.0' do
-  version '0.14.0'
-  sha256 'e728f9c5f64b9a7507f7038ad243743b4bcad0057fe7cc83021eb825cc2b6b9c'
+cask "terraform-0.14.0" do
+  version "0.14.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.0/terraform_0.14.0_darwin_amd64.zip"
+    sha256 "e728f9c5f64b9a7507f7038ad243743b4bcad0057fe7cc83021eb825cc2b6b9c"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.1.rb
+++ b/Casks/terraform-0.14.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.1' do
-  version '0.14.1'
-  sha256 '3077741547eaa8885aa0f8fb9ed160b6f069a55c8e8f908a316416a13c4407ca'
+cask "terraform-0.14.1" do
+  version "0.14.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.1/terraform_0.14.1_darwin_amd64.zip"
+    sha256 "3077741547eaa8885aa0f8fb9ed160b6f069a55c8e8f908a316416a13c4407ca"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.2.rb
+++ b/Casks/terraform-0.14.2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.2' do
-  version '0.14.2'
-  sha256 '31a7691f891f4e4c5d77b5eab9ecc86516df638a0b7cbde120c9e14bef68f7ac'
+cask "terraform-0.14.2" do
+  version "0.14.2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.2/terraform_0.14.2_darwin_amd64.zip"
+    sha256 "31a7691f891f4e4c5d77b5eab9ecc86516df638a0b7cbde120c9e14bef68f7ac"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.3.rb
+++ b/Casks/terraform-0.14.3.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.3' do
-  version '0.14.3'
-  sha256 'eda23614cd1dce1e96e7adf84f445c2783132c072fbd987f1f8858f34c361e41'
+cask "terraform-0.14.3" do
+  version "0.14.3"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.3/terraform_0.14.3_darwin_amd64.zip"
+    sha256 "eda23614cd1dce1e96e7adf84f445c2783132c072fbd987f1f8858f34c361e41"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.4.rb
+++ b/Casks/terraform-0.14.4.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.4' do
-  version '0.14.4'
-  sha256 '948d4550b7cd0f9152741c4a5e4fe80167b1cbb7513f939ffef1d50f94c4fb0c'
+cask "terraform-0.14.4" do
+  version "0.14.4"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.4/terraform_0.14.4_darwin_amd64.zip"
+    sha256 "948d4550b7cd0f9152741c4a5e4fe80167b1cbb7513f939ffef1d50f94c4fb0c"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.5.rb
+++ b/Casks/terraform-0.14.5.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.5' do
-  version '0.14.5'
-  sha256 '363d0e0c5c4cb4e69f5f2c7f64f9bf01ab73af0801665d577441521a24313a07'
+cask "terraform-0.14.5" do
+  version "0.14.5"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_darwin_amd64.zip"
+    sha256 "363d0e0c5c4cb4e69f5f2c7f64f9bf01ab73af0801665d577441521a24313a07"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.6.rb
+++ b/Casks/terraform-0.14.6.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.6' do
-  version '0.14.6'
-  sha256 '126e1c9e058f12c247a194db5a9567e59ec755cbc0211cd5d58c8b7d37412b2c'
+cask "terraform-0.14.6" do
+  version "0.14.6"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.6/terraform_0.14.6_darwin_amd64.zip"
+    sha256 "126e1c9e058f12c247a194db5a9567e59ec755cbc0211cd5d58c8b7d37412b2c"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.7.rb
+++ b/Casks/terraform-0.14.7.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.7' do
-  version '0.14.7'
-  sha256 '8a5ec04afcc9c2653bb927844eb76ad51e12bcaec0638103512d7b160dd530ea'
+cask "terraform-0.14.7" do
+  version "0.14.7"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_darwin_amd64.zip"
+    sha256 "8a5ec04afcc9c2653bb927844eb76ad51e12bcaec0638103512d7b160dd530ea"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.14.8.rb
+++ b/Casks/terraform-0.14.8.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.14.8' do
-  version '0.14.8'
-  sha256 '30115a2ee5f61178527089d8e5da20053927b364b08dc7aee6894a162ccbd793'
+cask "terraform-0.14.8" do
+  version "0.14.8"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.14.8/terraform_0.14.8_darwin_amd64.zip"
+    sha256 "30115a2ee5f61178527089d8e5da20053927b364b08dc7aee6894a162ccbd793"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.15.0-alpha20210107.rb
+++ b/Casks/terraform-0.15.0-alpha20210107.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.15.0-alpha20210107' do
-  version '0.15.0-alpha20210107'
-  sha256 '91d1c9424968c0efbc9ac5958e14bfe103981c885da1ace12114288884b8c855'
+cask "terraform-0.15.0-alpha20210107" do
+  version "0.15.0-alpha20210107"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.15.0-alpha20210107/terraform_0.15.0-alpha20210107_darwin_amd64.zip"
+    sha256 "91d1c9424968c0efbc9ac5958e14bfe103981c885da1ace12114288884b8c855"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.15.0-alpha20210127.rb
+++ b/Casks/terraform-0.15.0-alpha20210127.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.15.0-alpha20210127' do
-  version '0.15.0-alpha20210127'
-  sha256 '5053459451746b22df24fb42c4f767e247827c7bf1aa425e8636d5cec54ec28c'
+cask "terraform-0.15.0-alpha20210127" do
+  version "0.15.0-alpha20210127"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.15.0-alpha20210127/terraform_0.15.0-alpha20210127_darwin_amd64.zip"
+    sha256 "5053459451746b22df24fb42c4f767e247827c7bf1aa425e8636d5cec54ec28c"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.15.0-alpha20210210.rb
+++ b/Casks/terraform-0.15.0-alpha20210210.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.15.0-alpha20210210' do
-  version '0.15.0-alpha20210210'
-  sha256 '8585395617e78abe64cde98aec5495856f812d42ade11b3c9a6d50f5c76e9f06'
+cask "terraform-0.15.0-alpha20210210" do
+  version "0.15.0-alpha20210210"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.15.0-alpha20210210/terraform_0.15.0-alpha20210210_darwin_amd64.zip"
+    sha256 "8585395617e78abe64cde98aec5495856f812d42ade11b3c9a6d50f5c76e9f06"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.15.0-beta1.rb
+++ b/Casks/terraform-0.15.0-beta1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.15.0-beta1' do
-  version '0.15.0-beta1'
-  sha256 'bc4a4665af56c8e8bcf62788224f8fb91eeb7fe3b064ebcf3f3ab7bc5a90ea43'
+cask "terraform-0.15.0-beta1" do
+  version "0.15.0-beta1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.15.0-beta1/terraform_0.15.0-beta1_darwin_amd64.zip"
+    sha256 "bc4a4665af56c8e8bcf62788224f8fb91eeb7fe3b064ebcf3f3ab7bc5a90ea43"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.2.0.rb
+++ b/Casks/terraform-0.2.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.2.0' do
-  version '0.2.0'
-  sha256 '32c1c5d2df88c612207e9b5edea6f0f4c3bbdc8f2ae5f8c577ede2055548136b'
+cask "terraform-0.2.0" do
+  version "0.2.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.2.0/terraform_0.2.0_darwin_amd64.zip"
+    sha256 "32c1c5d2df88c612207e9b5edea6f0f4c3bbdc8f2ae5f8c577ede2055548136b"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.2.1.rb
+++ b/Casks/terraform-0.2.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.2.1' do
-  version '0.2.1'
-  sha256 '028076fa5b074d2b2457f857fe8f2182a8ef7a35c15b8c3b18a129df60790ea7'
+cask "terraform-0.2.1" do
+  version "0.2.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.2.1/terraform_0.2.1_darwin_amd64.zip"
+    sha256 "028076fa5b074d2b2457f857fe8f2182a8ef7a35c15b8c3b18a129df60790ea7"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.2.2.rb
+++ b/Casks/terraform-0.2.2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.2.2' do
-  version '0.2.2'
-  sha256 '1b4581e41e05145d2e9707cad5313636120a80b04cb796a503b3bfe59b6901d2'
+cask "terraform-0.2.2" do
+  version "0.2.2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.2.2/terraform_0.2.2_darwin_amd64.zip"
+    sha256 "1b4581e41e05145d2e9707cad5313636120a80b04cb796a503b3bfe59b6901d2"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.3.0.rb
+++ b/Casks/terraform-0.3.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.3.0' do
-  version '0.3.0'
-  sha256 '6c8eb551381eb331c0ef3f5615a60529bc45de1c702b02ed4dfa523cffa26084'
+cask "terraform-0.3.0" do
+  version "0.3.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.3.0/terraform_0.3.0_darwin_amd64.zip"
+    sha256 "6c8eb551381eb331c0ef3f5615a60529bc45de1c702b02ed4dfa523cffa26084"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.3.1.rb
+++ b/Casks/terraform-0.3.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.3.1' do
-  version '0.3.1'
-  sha256 'dda41425c7eb06c5e8b3f5ad4904e993aa8a9ab6b61f954ee2e259667cb6ff57'
+cask "terraform-0.3.1" do
+  version "0.3.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.3.1/terraform_0.3.1_darwin_amd64.zip"
+    sha256 "dda41425c7eb06c5e8b3f5ad4904e993aa8a9ab6b61f954ee2e259667cb6ff57"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.3.5.rb
+++ b/Casks/terraform-0.3.5.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.3.5' do
-  version '0.3.5'
-  sha256 'd583d58719951a5c3a06eec38390fe31bef7645af7fee3e915293aab7a910885'
+cask "terraform-0.3.5" do
+  version "0.3.5"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.3.5/terraform_0.3.5_darwin_amd64.zip"
+    sha256 "d583d58719951a5c3a06eec38390fe31bef7645af7fee3e915293aab7a910885"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.3.6.rb
+++ b/Casks/terraform-0.3.6.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.3.6' do
-  version '0.3.6'
-  sha256 '65b4c5bfc34bb0464b691b31ac554132c87ac0c5d7acef936c039777a27dccad'
+cask "terraform-0.3.6" do
+  version "0.3.6"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.3.6/terraform_0.3.6_darwin_amd64.zip"
+    sha256 "65b4c5bfc34bb0464b691b31ac554132c87ac0c5d7acef936c039777a27dccad"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.3.7.rb
+++ b/Casks/terraform-0.3.7.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.3.7' do
-  version '0.3.7'
-  sha256 'aecdc8119cd637e3e60967c97f9912735400814546b8e925152203fb6e99c732'
+cask "terraform-0.3.7" do
+  version "0.3.7"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.3.7/terraform_0.3.7_darwin_amd64.zip"
+    sha256 "aecdc8119cd637e3e60967c97f9912735400814546b8e925152203fb6e99c732"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.4.0.rb
+++ b/Casks/terraform-0.4.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.4.0' do
-  version '0.4.0'
-  sha256 'eba9a10b11d572bc5146c1d01353193ba45af2683a0977db09e7b18dff079398'
+cask "terraform-0.4.0" do
+  version "0.4.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.4.0/terraform_0.4.0_darwin_amd64.zip"
+    sha256 "eba9a10b11d572bc5146c1d01353193ba45af2683a0977db09e7b18dff079398"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.4.1.rb
+++ b/Casks/terraform-0.4.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.4.1' do
-  version '0.4.1'
-  sha256 '08bb2eaa5b4eae89963e5ed1598689d95d220c0cafb59bbd5f266f8e326ac944'
+cask "terraform-0.4.1" do
+  version "0.4.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.4.1/terraform_0.4.1_darwin_amd64.zip"
+    sha256 "08bb2eaa5b4eae89963e5ed1598689d95d220c0cafb59bbd5f266f8e326ac944"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.4.2.rb
+++ b/Casks/terraform-0.4.2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.4.2' do
-  version '0.4.2'
-  sha256 '317e2b9721394c1f6cc6710f13598cd91e8816b82fdc3781485556cadf1311dd'
+cask "terraform-0.4.2" do
+  version "0.4.2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.4.2/terraform_0.4.2_darwin_amd64.zip"
+    sha256 "317e2b9721394c1f6cc6710f13598cd91e8816b82fdc3781485556cadf1311dd"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.5.0.rb
+++ b/Casks/terraform-0.5.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.5.0' do
-  version '0.5.0'
-  sha256 '8033564434ed964fc630fe5ff8b4830945d38a528ad5b14e7a88e23f85591f05'
+cask "terraform-0.5.0" do
+  version "0.5.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.5.0/terraform_0.5.0_darwin_amd64.zip"
+    sha256 "8033564434ed964fc630fe5ff8b4830945d38a528ad5b14e7a88e23f85591f05"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.5.1.rb
+++ b/Casks/terraform-0.5.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.5.1' do
-  version '0.5.1'
-  sha256 '5915d7668b07ea3770f1bc8126764f90723eade0245e0634af3b051ae2ceb7e5'
+cask "terraform-0.5.1" do
+  version "0.5.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.5.1/terraform_0.5.1_darwin_amd64.zip"
+    sha256 "5915d7668b07ea3770f1bc8126764f90723eade0245e0634af3b051ae2ceb7e5"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.5.3.rb
+++ b/Casks/terraform-0.5.3.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.5.3' do
-  version '0.5.3'
-  sha256 '9d3388266510a03ea5f5ba2a721ab2affc854777c973d821f16e7dcd514adb7b'
+cask "terraform-0.5.3" do
+  version "0.5.3"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.5.3/terraform_0.5.3_darwin_amd64.zip"
+    sha256 "9d3388266510a03ea5f5ba2a721ab2affc854777c973d821f16e7dcd514adb7b"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.0.rb
+++ b/Casks/terraform-0.6.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.0' do
-  version '0.6.0'
-  sha256 'c519d3d18d5a2b0605bff6e0ca7bb677ea85c833f8e8dbb4af6a48e0ebf76cad'
+cask "terraform-0.6.0" do
+  version "0.6.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.0/terraform_0.6.0_darwin_amd64.zip"
+    sha256 "c519d3d18d5a2b0605bff6e0ca7bb677ea85c833f8e8dbb4af6a48e0ebf76cad"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.1.rb
+++ b/Casks/terraform-0.6.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.1' do
-  version '0.6.1'
-  sha256 'a06768862d1c3ee928d26961302c5134c9c8f716e567c4cf52fce85951f61bee'
+cask "terraform-0.6.1" do
+  version "0.6.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.1/terraform_0.6.1_darwin_amd64.zip"
+    sha256 "a06768862d1c3ee928d26961302c5134c9c8f716e567c4cf52fce85951f61bee"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.10.rb
+++ b/Casks/terraform-0.6.10.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.10' do
-  version '0.6.10'
-  sha256 '9009582111ba938bd7e22767f533c712fb763dffa9f390b40b17f18742bfac59'
+cask "terraform-0.6.10" do
+  version "0.6.10"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.10/terraform_0.6.10_darwin_amd64.zip"
+    sha256 "9009582111ba938bd7e22767f533c712fb763dffa9f390b40b17f18742bfac59"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.11.rb
+++ b/Casks/terraform-0.6.11.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.11' do
-  version '0.6.11'
-  sha256 '9802b1d56576bea86e34fd3800e100eb043ab6de5a5fa40f7f05a0a44f364dd2'
+cask "terraform-0.6.11" do
+  version "0.6.11"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.11/terraform_0.6.11_darwin_amd64.zip"
+    sha256 "9802b1d56576bea86e34fd3800e100eb043ab6de5a5fa40f7f05a0a44f364dd2"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.12.rb
+++ b/Casks/terraform-0.6.12.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.12' do
-  version '0.6.12'
-  sha256 'eaa50e05a88ef83a9ba18a3768932f4d530ce1b710b29ae29992f94addac0bfb'
+cask "terraform-0.6.12" do
+  version "0.6.12"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.12/terraform_0.6.12_darwin_amd64.zip"
+    sha256 "eaa50e05a88ef83a9ba18a3768932f4d530ce1b710b29ae29992f94addac0bfb"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.13.rb
+++ b/Casks/terraform-0.6.13.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.13' do
-  version '0.6.13'
-  sha256 '5f285ea0bf7f6bd704ef262330f88dc195ffa6ed118490d54961958dfe2dab24'
+cask "terraform-0.6.13" do
+  version "0.6.13"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.13/terraform_0.6.13_darwin_amd64.zip"
+    sha256 "5f285ea0bf7f6bd704ef262330f88dc195ffa6ed118490d54961958dfe2dab24"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.14+cf.rb
+++ b/Casks/terraform-0.6.14+cf.rb
@@ -1,8 +1,0 @@
-cask 'terraform-0.6.14+cf' do
-  version '0.6.14+cf'
-  sha256 '29b2f3ea691084a7f85504c39d07f84d7e8929efacaa30135470aebbbb26e53c'
-
-  url "https://homebrew-terraforms.s3.amazonaws.com/terraform_0.6.14%2Bcf_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
-end

--- a/Casks/terraform-0.6.14.rb
+++ b/Casks/terraform-0.6.14.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.14' do
-  version '0.6.14'
-  sha256 '9334f55a549d5cb3c583430be15e73b407bd7e115dc53db290381a482da17788'
+cask "terraform-0.6.14" do
+  version "0.6.14"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.14/terraform_0.6.14_darwin_amd64.zip"
+    sha256 "9334f55a549d5cb3c583430be15e73b407bd7e115dc53db290381a482da17788"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.15.rb
+++ b/Casks/terraform-0.6.15.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.15' do
-  version '0.6.15'
-  sha256 '9cb305ac00b85e2575da3c71504f3fdd3f7ef61f35457af999c7b88802143311'
+cask "terraform-0.6.15" do
+  version "0.6.15"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.15/terraform_0.6.15_darwin_amd64.zip"
+    sha256 "9cb305ac00b85e2575da3c71504f3fdd3f7ef61f35457af999c7b88802143311"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.16.rb
+++ b/Casks/terraform-0.6.16.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.16' do
-  version '0.6.16'
-  sha256 '23feb79263126877e6128a03c600cd626f6691a118a474694c5ad45cc5da9366'
+cask "terraform-0.6.16" do
+  version "0.6.16"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.16/terraform_0.6.16_darwin_amd64.zip"
+    sha256 "23feb79263126877e6128a03c600cd626f6691a118a474694c5ad45cc5da9366"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.2.rb
+++ b/Casks/terraform-0.6.2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.2' do
-  version '0.6.2'
-  sha256 '76a11f1ccd4af7881fab07ba7008a05ddf5ddeb25da2683c258619c9223d8162'
+cask "terraform-0.6.2" do
+  version "0.6.2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.2/terraform_0.6.2_darwin_amd64.zip"
+    sha256 "76a11f1ccd4af7881fab07ba7008a05ddf5ddeb25da2683c258619c9223d8162"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.3.rb
+++ b/Casks/terraform-0.6.3.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.3' do
-  version '0.6.3'
-  sha256 'd5c50b38bdba7dd11ccd31ebe04de9bb4a1f31a8b30ba967c863e3754d1bfd8b'
+cask "terraform-0.6.3" do
+  version "0.6.3"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.3/terraform_0.6.3_darwin_amd64.zip"
+    sha256 "d5c50b38bdba7dd11ccd31ebe04de9bb4a1f31a8b30ba967c863e3754d1bfd8b"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.4.rb
+++ b/Casks/terraform-0.6.4.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.4' do
-  version '0.6.4'
-  sha256 'e2eee073432487aabd69003b3a293caa6e087d4b435d29f6406079333e2dca73'
+cask "terraform-0.6.4" do
+  version "0.6.4"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.4/terraform_0.6.4_darwin_amd64.zip"
+    sha256 "e2eee073432487aabd69003b3a293caa6e087d4b435d29f6406079333e2dca73"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.5.rb
+++ b/Casks/terraform-0.6.5.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.5' do
-  version '0.6.5'
-  sha256 'ba540f36d1dc3ed9d3db9832db3a2b3f6cfea5d9f80b663281c1d28260d298ed'
+cask "terraform-0.6.5" do
+  version "0.6.5"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.5/terraform_0.6.5_darwin_amd64.zip"
+    sha256 "ba540f36d1dc3ed9d3db9832db3a2b3f6cfea5d9f80b663281c1d28260d298ed"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.6.rb
+++ b/Casks/terraform-0.6.6.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.6' do
-  version '0.6.6'
-  sha256 '43912f5d3eac34a73eaa182a78e13e8392ff4b81f053be4a61cd78db53c505a7'
+cask "terraform-0.6.6" do
+  version "0.6.6"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.6/terraform_0.6.6_darwin_amd64.zip"
+    sha256 "43912f5d3eac34a73eaa182a78e13e8392ff4b81f053be4a61cd78db53c505a7"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.7.rb
+++ b/Casks/terraform-0.6.7.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.7' do
-  version '0.6.7'
-  sha256 'fe54fa09af11a1375a2b85912fe416d494a52137be7c5b0b4aaae35d75b0d588'
+cask "terraform-0.6.7" do
+  version "0.6.7"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.7/terraform_0.6.7_darwin_amd64.zip"
+    sha256 "fe54fa09af11a1375a2b85912fe416d494a52137be7c5b0b4aaae35d75b0d588"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.8.rb
+++ b/Casks/terraform-0.6.8.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.8' do
-  version '0.6.8'
-  sha256 '71fd8ff20f657a4c7d82794756d55c55b0686516a8253356b8edd1a728230577'
+cask "terraform-0.6.8" do
+  version "0.6.8"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.8/terraform_0.6.8_darwin_amd64.zip"
+    sha256 "71fd8ff20f657a4c7d82794756d55c55b0686516a8253356b8edd1a728230577"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.6.9.rb
+++ b/Casks/terraform-0.6.9.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.6.9' do
-  version '0.6.9'
-  sha256 '9cf892c073a9fce0e9f136162f82c5b2d373c32cc2c5bd5c5eb16631262fad89'
+cask "terraform-0.6.9" do
+  version "0.6.9"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.6.9/terraform_0.6.9_darwin_amd64.zip"
+    sha256 "9cf892c073a9fce0e9f136162f82c5b2d373c32cc2c5bd5c5eb16631262fad89"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.0-rc1.rb
+++ b/Casks/terraform-0.7.0-rc1.rb
@@ -1,9 +1,0 @@
-cask 'terraform-0.7.0-rc1' do
-  version '0.7.0-rc1'
-  sha256 '04cb5d3fdb500ac83a2002006b4331a9e5db92c22b8b4971731c66a9fb8906ee'
-
-  # hashicorp.com is the official download host per the vendor homepage
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
-end

--- a/Casks/terraform-0.7.0-rc2.rb
+++ b/Casks/terraform-0.7.0-rc2.rb
@@ -1,9 +1,0 @@
-cask 'terraform-0.7.0-rc2' do
-  version '0.7.0-rc2'
-  sha256 'ade28697e57abd2b8a5dd35144bfbef946e2503362c3613340cff8ff7a99365b'
-
-  # hashicorp.com is the official download host per the vendor homepage
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
-end

--- a/Casks/terraform-0.7.0-rc3.rb
+++ b/Casks/terraform-0.7.0-rc3.rb
@@ -1,9 +1,0 @@
-cask 'terraform-0.7.0-rc3' do
-  version '0.7.0-rc3'
-  sha256 '2d34cf930f7ea7c983b3778645a00ad81612911b831525a438528b493b0e37b1'
-
-  # hashicorp.com is the official download host per the vendor homepage
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
-end

--- a/Casks/terraform-0.7.0-rc4.rb
+++ b/Casks/terraform-0.7.0-rc4.rb
@@ -1,9 +1,0 @@
-cask 'terraform-0.7.0-rc4' do
-  version '0.7.0-rc4'
-  sha256 '53d83150f333f3debde969d4cc8219772efe24d62812174ec4be86c64d7862d2'
-
-  # hashicorp.com is the official download host per the vendor homepage
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
-end

--- a/Casks/terraform-0.7.0.rb
+++ b/Casks/terraform-0.7.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.0' do
-  version '0.7.0'
-  sha256 '4720e4b2878b3b0d3d781f68ff363707ed42fe39cb89e2e34c6c11f8e0f76b04'
+cask "terraform-0.7.0" do
+  version "0.7.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.0/terraform_0.7.0_darwin_amd64.zip"
+    sha256 "4720e4b2878b3b0d3d781f68ff363707ed42fe39cb89e2e34c6c11f8e0f76b04"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.1.rb
+++ b/Casks/terraform-0.7.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.1' do
-  version '0.7.1'
-  sha256 'ab5e9ffe690f52ff13b8f095937119d67d3f0a07744be851657555236245dd98'
+cask "terraform-0.7.1" do
+  version "0.7.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.1/terraform_0.7.1_darwin_amd64.zip"
+    sha256 "ab5e9ffe690f52ff13b8f095937119d67d3f0a07744be851657555236245dd98"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.10.rb
+++ b/Casks/terraform-0.7.10.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.10' do
-  version '0.7.10'
-  sha256 'e65095c09cd94d60f0a6bc470ad29b249051448533344722755cc617bdd277a4'
+cask "terraform-0.7.10" do
+  version "0.7.10"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.10/terraform_0.7.10_darwin_amd64.zip"
+    sha256 "e65095c09cd94d60f0a6bc470ad29b249051448533344722755cc617bdd277a4"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.11.rb
+++ b/Casks/terraform-0.7.11.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.11' do
-  version '0.7.11'
-  sha256 '69c8d2b07f04e9bf0beb4a333dd189d8616d22fe46692bdb5aef10493ac5e5c6'
+cask "terraform-0.7.11" do
+  version "0.7.11"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.11/terraform_0.7.11_darwin_amd64.zip"
+    sha256 "69c8d2b07f04e9bf0beb4a333dd189d8616d22fe46692bdb5aef10493ac5e5c6"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.12.rb
+++ b/Casks/terraform-0.7.12.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.12' do
-  version '0.7.12'
-  sha256 'bfd79badf239509b09c5f036bd5cb1d688297644f26ffaf39d89c1abf9a2936d'
+cask "terraform-0.7.12" do
+  version "0.7.12"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.12/terraform_0.7.12_darwin_amd64.zip"
+    sha256 "bfd79badf239509b09c5f036bd5cb1d688297644f26ffaf39d89c1abf9a2936d"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.13.rb
+++ b/Casks/terraform-0.7.13.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.13' do
-  version '0.7.13'
-  sha256 'c1e004ad2bff4e92edb13cf32a18b67b5178fc3597a844beeda09cc4f9c30b65'
+cask "terraform-0.7.13" do
+  version "0.7.13"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.13/terraform_0.7.13_darwin_amd64.zip"
+    sha256 "c1e004ad2bff4e92edb13cf32a18b67b5178fc3597a844beeda09cc4f9c30b65"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.2.rb
+++ b/Casks/terraform-0.7.2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.2' do
-  version '0.7.2'
-  sha256 '2a441124efd097007414545714927a9239980a5b0707384b0ee07badbae781cf'
+cask "terraform-0.7.2" do
+  version "0.7.2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.2/terraform_0.7.2_darwin_amd64.zip"
+    sha256 "2a441124efd097007414545714927a9239980a5b0707384b0ee07badbae781cf"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.3.rb
+++ b/Casks/terraform-0.7.3.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.3' do
-  version '0.7.3'
-  sha256 'e0057e4f32e6490361611e3eb34e35f8b5314d861aa26fd9e89e1a7c4ab773bf'
+cask "terraform-0.7.3" do
+  version "0.7.3"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.3/terraform_0.7.3_darwin_amd64.zip"
+    sha256 "e0057e4f32e6490361611e3eb34e35f8b5314d861aa26fd9e89e1a7c4ab773bf"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.4.rb
+++ b/Casks/terraform-0.7.4.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.4' do
-  version '0.7.4'
-  sha256 '21c8ecc161628ecab88f45eba6b5ca1fbf3eb897e8bc951b0fbac4c0ad77fb04'
+cask "terraform-0.7.4" do
+  version "0.7.4"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.4/terraform_0.7.4_darwin_amd64.zip"
+    sha256 "21c8ecc161628ecab88f45eba6b5ca1fbf3eb897e8bc951b0fbac4c0ad77fb04"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.5.rb
+++ b/Casks/terraform-0.7.5.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.5' do
-  version '0.7.5'
-  sha256 '87cae476176b2f4416e5e0eb6c46ff218dd62201c31d3a3dfc16c08849d01b03'
+cask "terraform-0.7.5" do
+  version "0.7.5"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.5/terraform_0.7.5_darwin_amd64.zip"
+    sha256 "87cae476176b2f4416e5e0eb6c46ff218dd62201c31d3a3dfc16c08849d01b03"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.6.rb
+++ b/Casks/terraform-0.7.6.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.6' do
-  version '0.7.6'
-  sha256 '5c315498c58700d5e0eeba205c1e07e5299d04dd0f7fb7e87e4c38a8c9903774'
+cask "terraform-0.7.6" do
+  version "0.7.6"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.6/terraform_0.7.6_darwin_amd64.zip"
+    sha256 "5c315498c58700d5e0eeba205c1e07e5299d04dd0f7fb7e87e4c38a8c9903774"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.7.rb
+++ b/Casks/terraform-0.7.7.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.7' do
-  version '0.7.7'
-  sha256 'eb6255c4c14c61458ea4598a0e3176695c296e9f1650ad56a24a1cb75d8fef35'
+cask "terraform-0.7.7" do
+  version "0.7.7"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.7/terraform_0.7.7_darwin_amd64.zip"
+    sha256 "eb6255c4c14c61458ea4598a0e3176695c296e9f1650ad56a24a1cb75d8fef35"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.8.rb
+++ b/Casks/terraform-0.7.8.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.8' do
-  version '0.7.8'
-  sha256 '9daaec788ee0540d7b3a92f2dcf86656f3c567e2c267c64c03aa712901796470'
+cask "terraform-0.7.8" do
+  version "0.7.8"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.8/terraform_0.7.8_darwin_amd64.zip"
+    sha256 "9daaec788ee0540d7b3a92f2dcf86656f3c567e2c267c64c03aa712901796470"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.7.9.rb
+++ b/Casks/terraform-0.7.9.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.7.9' do
-  version '0.7.9'
-  sha256 '960e0e79c9dcaa51fa349f923e62f46fd4b49a91dcb06677ab096918f6074e2e'
+cask "terraform-0.7.9" do
+  version "0.7.9"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.7.9/terraform_0.7.9_darwin_amd64.zip"
+    sha256 "960e0e79c9dcaa51fa349f923e62f46fd4b49a91dcb06677ab096918f6074e2e"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.8.0-beta1.rb
+++ b/Casks/terraform-0.8.0-beta1.rb
@@ -1,8 +1,0 @@
-cask 'terraform-0.8.0-beta1' do
-  version '0.8.0-beta1'
-  sha256 '002b38431546f259fb89ed93e33fb7fe4371e616071deea74e81112d2a22c96e'
-
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
-end

--- a/Casks/terraform-0.8.0-beta2.rb
+++ b/Casks/terraform-0.8.0-beta2.rb
@@ -1,8 +1,0 @@
-cask 'terraform-0.8.0-beta2' do
-  version '0.8.0-beta2'
-  sha256 'd64cd70bb0446b29f4efa40512a2fe6fc7b2f7923d3a4e862ccf9345ae473e24'
-
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
-end

--- a/Casks/terraform-0.8.0-rc1.rb
+++ b/Casks/terraform-0.8.0-rc1.rb
@@ -1,8 +1,0 @@
-cask 'terraform-0.8.0-rc1' do
-  version '0.8.0-rc1'
-  sha256 '8b2284c1b4b61044771731000d781786432c149f918040bd698f5c9781e76772'
-
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
-end

--- a/Casks/terraform-0.8.0-rc2.rb
+++ b/Casks/terraform-0.8.0-rc2.rb
@@ -1,8 +1,0 @@
-cask 'terraform-0.8.0-rc2' do
-  version '0.8.0-rc2'
-  sha256 '37980a5cb36b7ef56084e779a07522d2ec26c42f86fa1e7e83f46875049690d9'
-
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
-end

--- a/Casks/terraform-0.8.0-rc3.rb
+++ b/Casks/terraform-0.8.0-rc3.rb
@@ -1,8 +1,0 @@
-cask 'terraform-0.8.0-rc3' do
-  version '0.8.0-rc3'
-  sha256 '2fb9519066cc4fddb530c457977b7bdaab4c1bc5cb471036dfb326e6c08a540f'
-
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
-end

--- a/Casks/terraform-0.8.0.rb
+++ b/Casks/terraform-0.8.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.8.0' do
-  version '0.8.0'
-  sha256 '4f4410be73200f95f84e359409481c8c48bc70e659fc5f7ea3f33a1db574ff65'
+cask "terraform-0.8.0" do
+  version "0.8.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.8.0/terraform_0.8.0_darwin_amd64.zip"
+    sha256 "4f4410be73200f95f84e359409481c8c48bc70e659fc5f7ea3f33a1db574ff65"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.8.1.rb
+++ b/Casks/terraform-0.8.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.8.1' do
-  version '0.8.1'
-  sha256 '275104513600bf50a28942131d928d2be405c75f9f36a9c722718500075856a1'
+cask "terraform-0.8.1" do
+  version "0.8.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.8.1/terraform_0.8.1_darwin_amd64.zip"
+    sha256 "275104513600bf50a28942131d928d2be405c75f9f36a9c722718500075856a1"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.8.2.rb
+++ b/Casks/terraform-0.8.2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.8.2' do
-  version '0.8.2'
-  sha256 '06bec1c06dbeb89ea7fdc2036be972372aa6847d3883786ab285386750a7ceb6'
+cask "terraform-0.8.2" do
+  version "0.8.2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.8.2/terraform_0.8.2_darwin_amd64.zip"
+    sha256 "06bec1c06dbeb89ea7fdc2036be972372aa6847d3883786ab285386750a7ceb6"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.8.3.rb
+++ b/Casks/terraform-0.8.3.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.8.3' do
-  version '0.8.3'
-  sha256 '84ecdd2adf61629a6bd4c1316df8f76290afad689630225d415666b422214a83'
+cask "terraform-0.8.3" do
+  version "0.8.3"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.8.3/terraform_0.8.3_darwin_amd64.zip"
+    sha256 "84ecdd2adf61629a6bd4c1316df8f76290afad689630225d415666b422214a83"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.8.4.rb
+++ b/Casks/terraform-0.8.4.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.8.4' do
-  version '0.8.4'
-  sha256 '79e94dfaf439fdbba2a2fe03dd7c90b24efa699b6661155aa9329df43e68ba51'
+cask "terraform-0.8.4" do
+  version "0.8.4"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.8.4/terraform_0.8.4_darwin_amd64.zip"
+    sha256 "79e94dfaf439fdbba2a2fe03dd7c90b24efa699b6661155aa9329df43e68ba51"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.8.5.rb
+++ b/Casks/terraform-0.8.5.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.8.5' do
-  version '0.8.5'
-  sha256 '10253ac843b7a170844d629cbdbd2287bf687cdd3d2938e4ab9140d10534cf38'
+cask "terraform-0.8.5" do
+  version "0.8.5"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.8.5/terraform_0.8.5_darwin_amd64.zip"
+    sha256 "10253ac843b7a170844d629cbdbd2287bf687cdd3d2938e4ab9140d10534cf38"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.8.6.rb
+++ b/Casks/terraform-0.8.6.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.8.6' do
-  version '0.8.6'
-  sha256 '0b80dedb16ab6583afcf66e9b03d3714fbfa44b827094420956d807b710e4fd6'
+cask "terraform-0.8.6" do
+  version "0.8.6"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.8.6/terraform_0.8.6_darwin_amd64.zip"
+    sha256 "0b80dedb16ab6583afcf66e9b03d3714fbfa44b827094420956d807b710e4fd6"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.8.7.rb
+++ b/Casks/terraform-0.8.7.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.8.7' do
-  version '0.8.7'
-  sha256 'ba53c7424bec5db7c01e0a5178ba5e295eb13669fb04fdae41576098baf88b75'
+cask "terraform-0.8.7" do
+  version "0.8.7"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.8.7/terraform_0.8.7_darwin_amd64.zip"
+    sha256 "ba53c7424bec5db7c01e0a5178ba5e295eb13669fb04fdae41576098baf88b75"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.8.8.rb
+++ b/Casks/terraform-0.8.8.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.8.8' do
-  version '0.8.8'
-  sha256 '55ab547539e68c9375c144062460457fcfdb3f5b9f412d3bb162f73298602d78'
+cask "terraform-0.8.8" do
+  version "0.8.8"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_darwin_amd64.zip"
+    sha256 "55ab547539e68c9375c144062460457fcfdb3f5b9f412d3bb162f73298602d78"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.9.0-beta1.rb
+++ b/Casks/terraform-0.9.0-beta1.rb
@@ -1,8 +1,0 @@
-cask 'terraform-0.9.0-beta1' do
-  version '0.9.0-beta1'
-  sha256 '7496efff0fe399f79967bc2dd0a03058d97c77648e6089a79cde86f6168b793c'
-
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
-end

--- a/Casks/terraform-0.9.0-beta2.rb
+++ b/Casks/terraform-0.9.0-beta2.rb
@@ -1,8 +1,0 @@
-cask 'terraform-0.9.0-beta2' do
-  version '0.9.0-beta2'
-  sha256 'b102ba7481e1310d96e70f499c58de48a753a45496d093d63897a3bc432636c2'
-
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
-end

--- a/Casks/terraform-0.9.0.rb
+++ b/Casks/terraform-0.9.0.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.9.0' do
-  version '0.9.0'
-  sha256 'b6de7307c989455c4b1f351c2df1ad1a0308edc71868bb432ad74f3980f8a6a3'
+cask "terraform-0.9.0" do
+  version "0.9.0"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.9.0/terraform_0.9.0_darwin_amd64.zip"
+    sha256 "b6de7307c989455c4b1f351c2df1ad1a0308edc71868bb432ad74f3980f8a6a3"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.9.1.rb
+++ b/Casks/terraform-0.9.1.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.9.1' do
-  version '0.9.1'
-  sha256 '4140c52917da91a276db34f01e5efc27d07b6e1deeede4137625fccf7bfabb83'
+cask "terraform-0.9.1" do
+  version "0.9.1"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.9.1/terraform_0.9.1_darwin_amd64.zip"
+    sha256 "4140c52917da91a276db34f01e5efc27d07b6e1deeede4137625fccf7bfabb83"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.9.10.rb
+++ b/Casks/terraform-0.9.10.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.9.10' do
-  version '0.9.10'
-  sha256 '8d55db3e114a72ec2cefb2e928af485c10f61c2df8121847972f73ca301fe5c6'
+cask "terraform-0.9.10" do
+  version "0.9.10"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.9.10/terraform_0.9.10_darwin_amd64.zip"
+    sha256 "8d55db3e114a72ec2cefb2e928af485c10f61c2df8121847972f73ca301fe5c6"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.9.11.rb
+++ b/Casks/terraform-0.9.11.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.9.11' do
-  version '0.9.11'
-  sha256 '31ca22b9b8e840789314085ea3a9a666af261b17c0f86b68dfedf1eb50345cbd'
+cask "terraform-0.9.11" do
+  version "0.9.11"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_darwin_amd64.zip"
+    sha256 "31ca22b9b8e840789314085ea3a9a666af261b17c0f86b68dfedf1eb50345cbd"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.9.2.rb
+++ b/Casks/terraform-0.9.2.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.9.2' do
-  version '0.9.2'
-  sha256 '33d9bbe1516a4085998c74d5a265aa0354d29a11eb56a21611dbcc806aec9c6f'
+cask "terraform-0.9.2" do
+  version "0.9.2"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.9.2/terraform_0.9.2_darwin_amd64.zip"
+    sha256 "33d9bbe1516a4085998c74d5a265aa0354d29a11eb56a21611dbcc806aec9c6f"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.9.3.rb
+++ b/Casks/terraform-0.9.3.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.9.3' do
-  version '0.9.3'
-  sha256 '180afdeb14f4049f3374fe02b9143ad428ebd31dd89c6595775d7ba439d7fbf0'
+cask "terraform-0.9.3" do
+  version "0.9.3"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.9.3/terraform_0.9.3_darwin_amd64.zip"
+    sha256 "180afdeb14f4049f3374fe02b9143ad428ebd31dd89c6595775d7ba439d7fbf0"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.9.4.rb
+++ b/Casks/terraform-0.9.4.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.9.4' do
-  version '0.9.4'
-  sha256 '73ec3c66a77e0c0879e6397fe2b4c4910b24464971fd0c27795b0fa09143f9ad'
+cask "terraform-0.9.4" do
+  version "0.9.4"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.9.4/terraform_0.9.4_darwin_amd64.zip"
+    sha256 "73ec3c66a77e0c0879e6397fe2b4c4910b24464971fd0c27795b0fa09143f9ad"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.9.5.rb
+++ b/Casks/terraform-0.9.5.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.9.5' do
-  version '0.9.5'
-  sha256 '83b5596c2a510925f90a6572d237b864bc4cf277609ebac294c8f400261e657c'
+cask "terraform-0.9.5" do
+  version "0.9.5"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.9.5/terraform_0.9.5_darwin_amd64.zip"
+    sha256 "83b5596c2a510925f90a6572d237b864bc4cf277609ebac294c8f400261e657c"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.9.6.rb
+++ b/Casks/terraform-0.9.6.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.9.6' do
-  version '0.9.6'
-  sha256 '71f53879c2fc33af57238cdb67a344d576ae3ae88f8db112122d433bd762788d'
+cask "terraform-0.9.6" do
+  version "0.9.6"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.9.6/terraform_0.9.6_darwin_amd64.zip"
+    sha256 "71f53879c2fc33af57238cdb67a344d576ae3ae88f8db112122d433bd762788d"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.9.7.rb
+++ b/Casks/terraform-0.9.7.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.9.7' do
-  version '0.9.7'
-  sha256 'ece7ad727eac202b571c64018ec3d09b4d7693aea7033db81e239d96d11d48b9'
+cask "terraform-0.9.7" do
+  version "0.9.7"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.9.7/terraform_0.9.7_darwin_amd64.zip"
+    sha256 "ece7ad727eac202b571c64018ec3d09b4d7693aea7033db81e239d96d11d48b9"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.9.8.rb
+++ b/Casks/terraform-0.9.8.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.9.8' do
-  version '0.9.8'
-  sha256 'f2f4e12bcb6e8bbd8876194221fbb79860ad700926d47a42654a354d70b06022'
+cask "terraform-0.9.8" do
+  version "0.9.8"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.9.8/terraform_0.9.8_darwin_amd64.zip"
+    sha256 "f2f4e12bcb6e8bbd8876194221fbb79860ad700926d47a42654a354d70b06022"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/Casks/terraform-0.9.9.rb
+++ b/Casks/terraform-0.9.9.rb
@@ -1,8 +1,14 @@
-cask 'terraform-0.9.9' do
-  version '0.9.9'
-  sha256 '657d522fc08b6f6fba0c913c9d474a80b1c9c1c6e9a497445455a8ff22fd72b3'
+cask "terraform-0.9.9" do
+  version "0.9.9"
 
-  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+  when :x86_64
+    url "https://releases.hashicorp.com/terraform/0.9.9/terraform_0.9.9_darwin_amd64.zip"
+    sha256 "657d522fc08b6f6fba0c913c9d474a80b1c9c1c6e9a497445455a8ff22fd72b3"
+  end
+
+  depends_on arch: [:x86_64]
 end

--- a/_cask_template.erb
+++ b/_cask_template.erb
@@ -1,8 +1,16 @@
-cask 'terraform-<%= version %>' do
-  version '<%= version %>'
-  sha256 '<%= sha256 %>'
+cask "terraform-<%= version %>" do
+  version "<%= version %>"
 
-  url "<%= url.gsub(version, '#{version}') %>"
-  name 'Terraform'
-  homepage 'https://www.terraform.io/'
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  case Hardware::CPU.arch
+<% cask_builds.each do |build| -%>
+  when <%= build.cask_arch.inspect %>
+    url "<%= build.url %>"
+    sha256 "<%= build.sha256 %>"
+<% end -%>
+  end
+
+  depends_on arch: <%= cask_archs %>
 end

--- a/scripts/add_new_terraform_casks
+++ b/scripts/add_new_terraform_casks
@@ -6,17 +6,19 @@ require 'json'
 require 'net/http'
 require 'uri'
 
+UPDATE_ALL = (ENV['UPDATE_ALL'] == 'yes')
+
 CASK_DIR = ENV['CASK_DIR'] || 'Casks'
 CASK_TEMPLATE = ENV['CASK_TEMPLATE'] || '_cask_template.erb'
+
+CASK_OS = 'darwin'
+CASK_ARCHS = %i[x86_64 arm64].freeze
 
 RELEASES_BASE_URL = 'https://releases.hashicorp.com/terraform'
 
 # Fetch all Terraform releases, and for each missing version add a Cask and
 # print out the version number.
 def add_new_terraform_casks
-  casks = Casks.new(cask_dir: CASK_DIR, template: CASK_TEMPLATE)
-  releases = TerraformReleases.new(base_url: RELEASES_BASE_URL)
-
   releases.sorted.each do |version|
     next if !update_all? && casks.include?(version)
 
@@ -29,52 +31,127 @@ def add_new_terraform_casks
   end
 end
 
+def casks
+  @casks ||= Casks.new
+end
+
+def releases
+  @releases ||= TerraformReleases.new
+end
+
 def update_all?
-  @update_all ||= (ENV['UPDATE_ALL'] == 'yes')
+  UPDATE_ALL
 end
 
 # All existing Terraform releases
 class TerraformReleases
   class ReleasesError < StandardError; end
+
   class VersionInfoError < StandardError; end
 
-  attr_reader :base_url
+  # One release version
+  class Release
+    attr_reader :version, :builds
 
-  def initialize(**opts)
-    @base_url = opts.fetch(:base_url)
+    def initialize(release_data)
+      @version = release_data.fetch('version')
+
+      shasums_file = release_data.fetch('shasums')
+      shasums = ShaSums.new("#{RELEASES_BASE_URL}/#{version}/#{shasums_file}")
+
+      @builds ||= release_data.fetch('builds').map { |build| Build.new(build, shasums) }
+    end
+
+    # Make public for ERB
+    def binding
+      super
+    end
+
+    # Builds suitable for Casks
+    def cask_builds
+      @cask_builds ||= builds.select(&:cask_arch?).tap do |builds|
+        raise VersionInfoError, "No builds found for v#{version}" if builds.empty?
+      end
+    end
+
+    def cask_archs
+      cask_builds.map(&:cask_arch)
+    end
+  end
+
+  # One arch specific build
+  class Build
+    attr_reader :version, :os, :arch, :url, :shasums
+
+    def initialize(build_data, shasums)
+      @version = build_data.fetch('version')
+      @os      = build_data.fetch('os')
+      @arch    = build_data.fetch('arch')
+      @url     = build_data.fetch('url')
+      @shasums = shasums
+    end
+
+    def cask_arch?
+      os == CASK_OS && CASK_ARCHS.include?(cask_arch)
+    end
+
+    def cask_arch
+      arch == 'amd64' ? :x86_64 : arch.to_sym
+    end
+
+    def sha256
+      shasums[self]
+    end
+  end
+
+  # Sha256sums for a Release
+  class ShaSums
+    attr_reader :url
+
+    def initialize(url)
+      @url = url
+    end
+
+    def [](build)
+      shasums.each_line do |line|
+        fields = line.split
+        return fields[0] if fields[1].include? "_#{build.os}_#{build.arch}."
+      end
+
+      raise VersionInfoError,
+            "Failed to find sha256 sum for #{build.os}/#{build.arch} v#{build.version}"
+    end
+
+    def shasums
+      @shasums ||= fetch_shasums
+    end
+
+    def fetch_shasums
+      res = Net::HTTP.get_response(URI(url))
+      return res.body if res.is_a?(Net::HTTPSuccess)
+
+      raise VersionInfoError,
+            "Failed to fetch sha256 sums from #{url}\n-> #{res.code} #{res.message}"
+    end
+  end
+
+  attr_reader :releases_url
+
+  def initialize
+    @releases_url = "#{RELEASES_BASE_URL}/index.json"
   end
 
   def versions
     @versions ||= fetch_releases
   end
 
-  # Returns information of the specified release
-  def [](version)
-    release = versions.fetch(version)
-    {
-      version: version,
-      url: download_url(release),
-      sha256: fetch_sha256sum(release)
-    }
-  end
-
   def sorted
     versions.keys.sort_by { |v| Gem::Version.new(v) }
   end
 
-  def releases_url
-    "#{base_url}/index.json"
-  end
-
-  def shasums_url(release)
-    "#{base_url}/#{release.fetch('version')}/#{release.fetch('shasums')}"
-  end
-
-  def download_url(release)
-    release.fetch('builds').each do |build|
-      return build['url'] if build['os'] == 'darwin' && build['arch'] == 'amd64'
-    end
-    raise VersionInfoError, "No build found for v#{release['version']}"
+  # Returns the specified release
+  def [](version)
+    Release.new(versions.fetch(version))
   end
 
   def fetch_releases
@@ -85,53 +162,27 @@ class TerraformReleases
           "Failed to fetch Terraform releases from #{releases_url}\n" \
           "-> #{res.code} #{res.message}"
   end
-
-  def fetch_sha256sum(release)
-    url = shasums_url(release)
-    res = Net::HTTP.get_response(URI(url))
-    return parse_sha(res.body, release) if res.is_a?(Net::HTTPSuccess)
-
-    raise VersionInfoError,
-          "Failed to fetch sha256 sums from #{url}\n-> #{res.code} #{res.message}"
-  end
-
-  def parse_sha(data, release)
-    data.each_line do |line|
-      fields = line.split
-      return fields[0] if fields[1] =~ /_darwin_amd64/
-    end
-
-    raise VersionInfoError,
-          "Failed to find sha256 sum for v#{release['version']}"
-  end
 end
 
 # Terraform Casks in this repository
 class Casks
-  attr_reader :cask_dir, :template_file
-
-  def initialize(**opts)
-    @cask_dir = opts.fetch(:cask_dir)
-    @template_file = opts.fetch(:template)
-  end
-
   def include?(version)
     versions.include?(version)
   end
 
-  def add(version_info)
-    cask_file = File.join(cask_dir, "terraform-#{version_info[:version]}.rb")
-    IO.write(cask_file, template.result_with_hash(version_info))
+  def add(release)
+    cask_file = File.join(CASK_DIR, "terraform-#{release.version}.rb")
+    IO.write(cask_file, template.result(release.binding))
   end
 
   def versions
-    @versions ||= Dir.glob(File.join(cask_dir, 'terraform-*.rb')).map do |file|
+    @versions ||= Dir.glob(File.join(CASK_DIR, 'terraform-*.rb')).map do |file|
       File.basename(file, '.rb').sub(/^terraform-/, '')
     end
   end
 
   def template
-    @template ||= ERB.new(IO.read(template_file))
+    @template ||= ERB.new(IO.read(CASK_TEMPLATE), trim_mode: '-')
   end
 end
 


### PR DESCRIPTION
Add support for incoming arm64 builds by generating arch specific urls and hashes for the Casks.

Regenerate the current Casks, and remove the disappeared old pre-releases. Future arm64 builds should be included automatically.

#81