### PR TITLE
update brew cask install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then select the wanted Terraform version to use with `chtf`.
 
 You can also just install a specific Terraform version (but you'll need to use `chtf` or adjust `PATH` yourself to use it):
 
-    brew cask install terraform-0.6.9
+    brew install --cask terraform-0.6.9
 
 ## Contibuting
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524