### PR TITLE
[Casks] sha256 of lots of Terraform releases changed

### DIFF
--- a/Casks/terraform-0.11.15-oci.rb
+++ b/Casks/terraform-0.11.15-oci.rb
@@ -7,7 +7,7 @@ cask "terraform-0.11.15-oci" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.11.15-oci/terraform_0.11.15-oci_darwin_amd64.zip"
-    sha256 "4ac1b0a1a7ee9e04165ce035300eddf9119124046d63fc4bfeffcc88fc6365bb"
+    sha256 "52e20f74001af262792ea379be3eb7f169420646e48514d063ffe2591a844821"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.11.15.rb
+++ b/Casks/terraform-0.11.15.rb
@@ -7,7 +7,7 @@ cask "terraform-0.11.15" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_darwin_amd64.zip"
-    sha256 "b0d2c9f9068be007f9b8eff211a679e1f07368b640245871bb02a6c2cdf28c07"
+    sha256 "e98434b0d35c4ec058479148dd590d2bbf3e419fcc6db204522cc4b0bbd9ec25"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.10.rb
+++ b/Casks/terraform-0.12.10.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.10" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.10/terraform_0.12.10_darwin_amd64.zip"
-    sha256 "d97db2217c6050926eedf517b7b0427b1b5f1bda989742cfd33d8fe56c95bb05"
+    sha256 "1a4f17da540d68c015d693f8a88dd873b514bdfe1d65dfbf6f7a0af3768c3104"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.11.rb
+++ b/Casks/terraform-0.12.11.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.11" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.11/terraform_0.12.11_darwin_amd64.zip"
-    sha256 "e1ddcd5f40d3e9b2758d8bc4858117f5df94169fec16495dada96d3ab358ff34"
+    sha256 "8f54fa6256ec4c4a6a1e0094e39825fb7287ef4b4680d9a133ec6dda18b80e29"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.12.rb
+++ b/Casks/terraform-0.12.12.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.12" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.12/terraform_0.12.12_darwin_amd64.zip"
-    sha256 "51507dedba7fcc2638c5c2c40206ec604155e2d3067a132b618f4e99ea9f1db9"
+    sha256 "c97c51f40d2709143bbefdf7ac9130fc518a0ef337706e7ebdde36cc6056219e"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.13.rb
+++ b/Casks/terraform-0.12.13.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.13" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.13/terraform_0.12.13_darwin_amd64.zip"
-    sha256 "744dfa3c4f566cabddf2fa6b3b19fab06d512f3c654c09906e8acaaaa2388cfb"
+    sha256 "ff0ca1bd75c64b0811d3c79d7cce23e9011426efc6851ba7b6c92b7ae1a4cfb4"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.14.rb
+++ b/Casks/terraform-0.12.14.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.14" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.14/terraform_0.12.14_darwin_amd64.zip"
-    sha256 "2a4538ccf212865cb2c275dc079926f409b3809cb589638f560d5ab389babe00"
+    sha256 "ce2addedea513861c21158988a10ab3e15c20c19c9b67c2891ccf97cf87934d6"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.15.rb
+++ b/Casks/terraform-0.12.15.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.15" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.15/terraform_0.12.15_darwin_amd64.zip"
-    sha256 "c1ec56b36e8395a454b7d0ba421aa42c54d2f91c913893447d20aecf1437623f"
+    sha256 "b3aa81bd0dd2b5a3c89a82afa7b32291bc6b09e2cdbc4909bb7da14ff9da4d24"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.16.rb
+++ b/Casks/terraform-0.12.16.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.16" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.16/terraform_0.12.16_darwin_amd64.zip"
-    sha256 "02f893e326b25705aff2594d9f28a4a0c9d50f44a0e7e7129633f02c11a2e47d"
+    sha256 "c75ad22dd0d512531e4fed2e4e6ba6afc294ab43d33e01e144d63acfff0d8b3c"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.17.rb
+++ b/Casks/terraform-0.12.17.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.17" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.17/terraform_0.12.17_darwin_amd64.zip"
-    sha256 "b0ab66e77bac3abcd8b36afa5e567ab4fef103fc21c4a223c954c4ea60f5d244"
+    sha256 "b0a3fe53880b074cfb173b492cf6891ff3cd2614589570af04a73a64cc12deb5"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.18.rb
+++ b/Casks/terraform-0.12.18.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.18" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.18/terraform_0.12.18_darwin_amd64.zip"
-    sha256 "dd6983cfe0d0922de51e019a80db2a270e8a2636b9f05b49bf7dcbfe7bd90ea9"
+    sha256 "0a64060a1342e7102d6d0e50104ac7a5192e8bf9a8816bd350c581a19efecabe"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.19.rb
+++ b/Casks/terraform-0.12.19.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.19" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.19/terraform_0.12.19_darwin_amd64.zip"
-    sha256 "5238fe45d051cac90f0fc0701796c5244ef88218d0fe4eceec31cee43899a434"
+    sha256 "4d7be70cfbaaa17828a59cbe03db255d44cfc342658aa5c36a2153b84b9ec1c1"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.20.rb
+++ b/Casks/terraform-0.12.20.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.20" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.20/terraform_0.12.20_darwin_amd64.zip"
-    sha256 "9e2ef974618402b70d4491f50701621e1a9f1cb32862592f0af3fee12324d378"
+    sha256 "d814abcba5fded1ad71fca9b133c744d9b62d69dda02d206edcd9d72656d2ef2"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.21.rb
+++ b/Casks/terraform-0.12.21.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.21" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.21/terraform_0.12.21_darwin_amd64.zip"
-    sha256 "f89b620e59439fccc80950bbcbd37a069101cbef7029029a12227eee831e463f"
+    sha256 "2c9dd0e08cf808f532710e97392f67bcccc3bc8f9fe6cc040237c62940ee6b48"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.22.rb
+++ b/Casks/terraform-0.12.22.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.22" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.22/terraform_0.12.22_darwin_amd64.zip"
-    sha256 "13d0dd4a4c7cb5dea403c1a02dd9200ff9de086e8ddd832ffea2219c59d33fe1"
+    sha256 "efb9b86830b08e20723acaf4f2eadb3ff934fb9a89584afaaf20b9572a955de6"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.23.rb
+++ b/Casks/terraform-0.12.23.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.23" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.23/terraform_0.12.23_darwin_amd64.zip"
-    sha256 "ca1a0bc58b4e482d0bdcaee95d002f4901094935fd4b184f57563a5c34fd18d9"
+    sha256 "dc0586ac38232e2b50251efcca3b9911cf263d285a8cf3c0b68538dbdb3b72f4"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.24.rb
+++ b/Casks/terraform-0.12.24.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.24" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_darwin_amd64.zip"
-    sha256 "72482000a5e25c33e88e95d70208304acfd09bf855a7ede110da032089d13b4f"
+    sha256 "c67a5870977372cf0761de57403abd0bec4d82a18e2cbac1b4e0f25d4bc4c838"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.25.rb
+++ b/Casks/terraform-0.12.25.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.25" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.25/terraform_0.12.25_darwin_amd64.zip"
-    sha256 "179fc99ccea5ed3617e9e7026dcfa59a5916ea91162afd7a2acd8350906a0d68"
+    sha256 "6c5160a6e1ede47be445d4c4f48e77da4a2f508e278738cb0ccc6c3104102783"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.26.rb
+++ b/Casks/terraform-0.12.26.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.26" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.26/terraform_0.12.26_darwin_amd64.zip"
-    sha256 "79fb293324012bc981006e1527267987666dd80cff80b11f93fb0ab2e321c450"
+    sha256 "d100f6949ba4de1f44ba02cac02550e416bfed93b31c0bcc082a3772ff22de1d"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.27.rb
+++ b/Casks/terraform-0.12.27.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.27" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.27/terraform_0.12.27_darwin_amd64.zip"
-    sha256 "3941e8b3f81257e54997cd717cec5dfbf3a254643a47e3ac8c687f26c0b8814f"
+    sha256 "7bd1f1a45393d360db68d8338a40f56c1448c30c932353d5e26ffe5dbdefab50"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.28.rb
+++ b/Casks/terraform-0.12.28.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.28" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.28/terraform_0.12.28_darwin_amd64.zip"
-    sha256 "893050bcfc5e7445acd3a30f1500227b989b29cbd958ca64a8233589194a198d"
+    sha256 "fee2663bbe4d80149f6c1df166c780380e7c7500d87f100678eb66784adc0283"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.29.rb
+++ b/Casks/terraform-0.12.29.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.29" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_darwin_amd64.zip"
-    sha256 "fdcda98ff7b7e65832248f64ef6c2922e05036de25d40c5cdcd732c5117150aa"
+    sha256 "756b5d0d3d22d3d9f4d70aa79612e8137230228f491c2dba885c37130815e7cf"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.30.rb
+++ b/Casks/terraform-0.12.30.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.30" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.30/terraform_0.12.30_darwin_amd64.zip"
-    sha256 "f107ed316be1b86a63df4e47a1fb8ab8c9ffdbbc606dcdf90043f91bdb21826d"
+    sha256 "cf7df9be4c5261a7fbca0438380379c408cd49d12fbd1bbeb9faafb696790021"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.31.rb
+++ b/Casks/terraform-0.12.31.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.31" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_darwin_amd64.zip"
-    sha256 "c1a6ca04026cebe7849610037ebc960609484c25f47a58344efaa7fcd5be1e56"
+    sha256 "794e736283b93b364d7f1c36ec8f47912ec6f6a0692b2108d0fb3908b5d3b5af"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.7.rb
+++ b/Casks/terraform-0.12.7.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_darwin_amd64.zip"
-    sha256 "5cb59cdc4a8c4ebdfc0b8715936110e707d869c59603d27020e33b2be2e50f21"
+    sha256 "3d177358812c3d40259aed68adbc369c0ce17c5127763a9ac79b270378555467"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.8.rb
+++ b/Casks/terraform-0.12.8.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.8" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.8/terraform_0.12.8_darwin_amd64.zip"
-    sha256 "2c2d9d435712f4be989738b7899917ced7c12ab05b8ddc14359ed4ddb1bc9375"
+    sha256 "f4b80a1b04246c9b7cf2689a69f8f68f9b07e53b568c1329bcc8cd87dcd38e39"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.9.rb
+++ b/Casks/terraform-0.12.9.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.9" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_darwin_amd64.zip"
-    sha256 "dbb3c0ffb37a5e659e05b8c223a717f89ffda7761d23eaf596c31b9745557288"
+    sha256 "5751e34b5d1641c9661420ea69b4e60d96f5cafdb5a7bcfe7804f036c5f0c0c6"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.0-beta1.rb
+++ b/Casks/terraform-0.13.0-beta1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.0-beta1/terraform_0.13.0-beta1_darwin_amd64.zip"
-    sha256 "dfdc8ef005df19d7ec0fcb5f151e51b144233ca425c39dabf94c037e80780b05"
+    sha256 "9c24cd6e18482b7b5ddc60e00ea08b52e0b1f18b01d8b3196f1dadeea59647bd"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.0-beta2.rb
+++ b/Casks/terraform-0.13.0-beta2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.0-beta2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.0-beta2/terraform_0.13.0-beta2_darwin_amd64.zip"
-    sha256 "4729fa267c5be7f1d0c19a85d36e2b4577f303866fc25403650acb4243c2021f"
+    sha256 "ffe52a79916102639a3b2646be237fe7b2748436c8c198099cc87c0a615ac9c2"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.0-beta3.rb
+++ b/Casks/terraform-0.13.0-beta3.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.0-beta3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.0-beta3/terraform_0.13.0-beta3_darwin_amd64.zip"
-    sha256 "8e49d45da847120ea1e162d0b3fcd6b322e8dff419c6cc5cb535a3041a650391"
+    sha256 "dc867d549b1c7140d22e6a5f41fbcaa4d4db9190d191ed1b8c3ab9e1a1afa655"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.0-rc1.rb
+++ b/Casks/terraform-0.13.0-rc1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.0-rc1/terraform_0.13.0-rc1_darwin_amd64.zip"
-    sha256 "cf24555d0089947d690dbb4860bc7f4206da5b71092f150c4785185b2ed837cd"
+    sha256 "6920d32c38c8942e853b29041932cdf1174dca177fc9f0bf7b2f0e9869b139b5"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.0.rb
+++ b/Casks/terraform-0.13.0.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.0/terraform_0.13.0_darwin_amd64.zip"
-    sha256 "080af0420732cd08941aa4c0d2b4693056b24366724faa11b107bf052f7de203"
+    sha256 "d21665e66ded549916804449fb93bb743ddd60847b31f429c241cbbcb5a0f563"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.1.rb
+++ b/Casks/terraform-0.13.1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.1_darwin_amd64.zip"
-    sha256 "fe5d1b6e22892c5dcc8b44d2a26ea1e29d90af6fcb1472f3881ca3c08c8a8084"
+    sha256 "1c6466be64700f1ae718432789ff2d553076da1de63e08e818de0e478e9eb4e2"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.2.rb
+++ b/Casks/terraform-0.13.2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_darwin_amd64.zip"
-    sha256 "7af2f9c03e8687c87e7798178a2dac9a3061955eb19f0f69501475e017b8d8f6"
+    sha256 "e6acad92937713255227030559d49b1df18d75abf2add087906f4f47ec6fa585"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.3.rb
+++ b/Casks/terraform-0.13.3.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_darwin_amd64.zip"
-    sha256 "ccbfd3af8732a47b6bd32c419e1a52e41eb8a39ff7437afffbef438b5c0f92c3"
+    sha256 "f74d0443acfb707c90241faf20071a973877ba24c1a12d57ba553be096fa628c"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.4.rb
+++ b/Casks/terraform-0.13.4.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.4/terraform_0.13.4_darwin_amd64.zip"
-    sha256 "d16d3094b0f9f56d7e05b4c09a923141a483f51e58613ae64507b0f7ba45bb34"
+    sha256 "074f88409e7b1aab095231841e5920255690520d499d8c41c397e49f16c3de15"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.5.rb
+++ b/Casks/terraform-0.13.5.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_darwin_amd64.zip"
-    sha256 "03f7b636638c587c3b03a4b3d1d4cab77c872ad5f7e55405ddaf38dfb94e0e89"
+    sha256 "7c196875d9d9f03c6218581622bb5e66f15a98de764a8daf09eb40183d2145ce"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.6.rb
+++ b/Casks/terraform-0.13.6.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.6" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.6/terraform_0.13.6_darwin_amd64.zip"
-    sha256 "cbb76aed9c01a8c0fbee4e3a10112ab7836440fa63d93414a1dc45ef59bc0ea2"
+    sha256 "1df49e6f05804a08a7f9d3ea6c393d20ae43e2a74722cd64f3e120d49e0b57d4"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.7.rb
+++ b/Casks/terraform-0.13.7.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_darwin_amd64.zip"
-    sha256 "d5fbb589bc35c2655d0705c26117135cbb25e4259f120415009e0e6427ea97c8"
+    sha256 "2ee62413afc847d9771d46d73fad6c7e8670bcdf44190320b5fb6a3a38ec6480"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0-alpha20200910.rb
+++ b/Casks/terraform-0.14.0-alpha20200910.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0-alpha20200910" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0-alpha20200910/terraform_0.14.0-alpha20200910_darwin_amd64.zip"
-    sha256 "2e65f929c74134f2a40ae1f092097c24159186e5ac58fbf19841a21b9f575893"
+    sha256 "2068bbedc098668b7a84ba08069ddb4a4622d782ee4f3b0eaf5dd034273da0b0"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0-alpha20200923.rb
+++ b/Casks/terraform-0.14.0-alpha20200923.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0-alpha20200923" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0-alpha20200923/terraform_0.14.0-alpha20200923_darwin_amd64.zip"
-    sha256 "7d7e888fdd28abfe00894f9055209b9eec785153641de98e6852aa071008d4ee"
+    sha256 "03fbdbca7f40731b58b0925dc55010a1d99c294b4cc9d6c4faa2472fc63284de"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0-alpha20201007.rb
+++ b/Casks/terraform-0.14.0-alpha20201007.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0-alpha20201007" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0-alpha20201007/terraform_0.14.0-alpha20201007_darwin_amd64.zip"
-    sha256 "f2689edb2dbe46fafbdf92062a37c695d398d5224756c57db62fae8097f54a0a"
+    sha256 "a334ee3d6195e3aa39127bbff36c7ec614f8758d85d70259341a1e9934595a59"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0-beta1.rb
+++ b/Casks/terraform-0.14.0-beta1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0-beta1/terraform_0.14.0-beta1_darwin_amd64.zip"
-    sha256 "10c5c0969438f973a25cffcae3e567697822459da3ff177d707f3ae2d5100962"
+    sha256 "691ec8a5be44b78e306123c033961d841506b6af54c511cef22bfb7385008361"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0-beta2.rb
+++ b/Casks/terraform-0.14.0-beta2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0-beta2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0-beta2/terraform_0.14.0-beta2_darwin_amd64.zip"
-    sha256 "fc9c78035efa97c36b2abf590d562fe99ffb9d0fb3224c3b0fb6f80fff4d2754"
+    sha256 "377213a1387367358b1f81cb46faaa1c3ccdeedab1d4afea39efd6997d534391"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0-rc1.rb
+++ b/Casks/terraform-0.14.0-rc1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0-rc1/terraform_0.14.0-rc1_darwin_amd64.zip"
-    sha256 "6fcb3898b33887fdd3c8f14cf92783a52bdab224164db972e65301f30baac3df"
+    sha256 "578803405810e49a23ddb694299062561b456f69d7a3a0162aab13fdba3aef17"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0.rb
+++ b/Casks/terraform-0.14.0.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0/terraform_0.14.0_darwin_amd64.zip"
-    sha256 "e728f9c5f64b9a7507f7038ad243743b4bcad0057fe7cc83021eb825cc2b6b9c"
+    sha256 "b0c216023e42e69c09b953653c22f0421a2d24a62c124cd89adf468165de70ea"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.1.rb
+++ b/Casks/terraform-0.14.1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.1/terraform_0.14.1_darwin_amd64.zip"
-    sha256 "3077741547eaa8885aa0f8fb9ed160b6f069a55c8e8f908a316416a13c4407ca"
+    sha256 "06704f482319c703aa155ae9c2d3c8cd42ad2d8fcce3de8644dc29354bb52d80"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.10.rb
+++ b/Casks/terraform-0.14.10.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.10" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.10/terraform_0.14.10_darwin_amd64.zip"
-    sha256 "4b2acb55c6350cba92769c852d4502dff3e185726fc5293e3ab0bb64393846c4"
+    sha256 "26890407b6580adef5fdfdf87f9cca3047d061230191af55d49774522e8f8eb5"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.11.rb
+++ b/Casks/terraform-0.14.11.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.11" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_darwin_amd64.zip"
-    sha256 "5c0110a4dc44ec01edd159c69bf60cebd18540eaf168aacd8b37d828b70e265d"
+    sha256 "143ee31a4ae61564762ca5fe40851a0ec661698b73026e3cc0061f9867c7b67f"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.2.rb
+++ b/Casks/terraform-0.14.2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.2/terraform_0.14.2_darwin_amd64.zip"
-    sha256 "31a7691f891f4e4c5d77b5eab9ecc86516df638a0b7cbde120c9e14bef68f7ac"
+    sha256 "02b71faa013ae13ddfe82181a0d8a5774ac915811aab01064edcb0104993b101"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.3.rb
+++ b/Casks/terraform-0.14.3.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.3/terraform_0.14.3_darwin_amd64.zip"
-    sha256 "eda23614cd1dce1e96e7adf84f445c2783132c072fbd987f1f8858f34c361e41"
+    sha256 "68ba55ae728d8f568ea464adf897e265bc51c38452880a08632b7b76f11dd7dd"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.4.rb
+++ b/Casks/terraform-0.14.4.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.4/terraform_0.14.4_darwin_amd64.zip"
-    sha256 "948d4550b7cd0f9152741c4a5e4fe80167b1cbb7513f939ffef1d50f94c4fb0c"
+    sha256 "b69403f2893ddcd3cb7bd9d6d45627862f9eb88c1a1e2dd6e26560055a45b50b"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.5.rb
+++ b/Casks/terraform-0.14.5.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_darwin_amd64.zip"
-    sha256 "363d0e0c5c4cb4e69f5f2c7f64f9bf01ab73af0801665d577441521a24313a07"
+    sha256 "4b8633c12e999b0b8cc40cfb3b8b9b9a82d68b05334a188a7f842cbfa4efb495"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.6.rb
+++ b/Casks/terraform-0.14.6.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.6" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.6/terraform_0.14.6_darwin_amd64.zip"
-    sha256 "126e1c9e058f12c247a194db5a9567e59ec755cbc0211cd5d58c8b7d37412b2c"
+    sha256 "8a8086cab3a7fd812dd5e6ba9801bea1eaab154d5b53e4a9d50850231c1bd7a3"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.7.rb
+++ b/Casks/terraform-0.14.7.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_darwin_amd64.zip"
-    sha256 "8a5ec04afcc9c2653bb927844eb76ad51e12bcaec0638103512d7b160dd530ea"
+    sha256 "35dbd2e1bd3efdfabbba8c907bd08c4e762e8b15bbc33cb6a38467bfc2c27539"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.8.rb
+++ b/Casks/terraform-0.14.8.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.8" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.8/terraform_0.14.8_darwin_amd64.zip"
-    sha256 "30115a2ee5f61178527089d8e5da20053927b364b08dc7aee6894a162ccbd793"
+    sha256 "8920b658fd03722d44acaae4a633d72cffe425cab4cbbea7b0c28d5ea7f72127"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.9.rb
+++ b/Casks/terraform-0.14.9.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.9" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.9/terraform_0.14.9_darwin_amd64.zip"
-    sha256 "96d0b1c807415ba295a70e8afed04e233778673103587f321164ebb96be123d8"
+    sha256 "606357dfdb39d5b6ae39c2b81c9468ae9cd42f02dadfc9174232cd1b974adf9b"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-alpha20210107.rb
+++ b/Casks/terraform-0.15.0-alpha20210107.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-alpha20210107" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-alpha20210107/terraform_0.15.0-alpha20210107_darwin_amd64.zip"
-    sha256 "91d1c9424968c0efbc9ac5958e14bfe103981c885da1ace12114288884b8c855"
+    sha256 "aa26215c955041732313a82a1f65174e5ddc20f27c857b46a90867602ea48423"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-alpha20210127.rb
+++ b/Casks/terraform-0.15.0-alpha20210127.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-alpha20210127" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-alpha20210127/terraform_0.15.0-alpha20210127_darwin_amd64.zip"
-    sha256 "5053459451746b22df24fb42c4f767e247827c7bf1aa425e8636d5cec54ec28c"
+    sha256 "02b3d4dcbd9959f31b7cfac5b1abf3bcf6298d73c2fc07e7df1a611cc5c71f55"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-alpha20210210.rb
+++ b/Casks/terraform-0.15.0-alpha20210210.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-alpha20210210" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-alpha20210210/terraform_0.15.0-alpha20210210_darwin_amd64.zip"
-    sha256 "8585395617e78abe64cde98aec5495856f812d42ade11b3c9a6d50f5c76e9f06"
+    sha256 "5bb761dc863faa4471b33bb2fb293e27a8af7eb201c35bb10d2ce7e8ddfb20bd"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-beta1.rb
+++ b/Casks/terraform-0.15.0-beta1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-beta1/terraform_0.15.0-beta1_darwin_amd64.zip"
-    sha256 "bc4a4665af56c8e8bcf62788224f8fb91eeb7fe3b064ebcf3f3ab7bc5a90ea43"
+    sha256 "fac5a5e595344b68ccc3c06208cc310e3da0602c2f1cdb794bfa074d4d2dbe93"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-beta2.rb
+++ b/Casks/terraform-0.15.0-beta2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-beta2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-beta2/terraform_0.15.0-beta2_darwin_amd64.zip"
-    sha256 "f66f7fa95ad276198bea21cd960d377be3f9dbe16e91ee628c2f29684bafacee"
+    sha256 "c974ca266dd8efbfda4303c96e2add991a7a96f32665b580cfc727099aa36e21"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-rc1.rb
+++ b/Casks/terraform-0.15.0-rc1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-rc1/terraform_0.15.0-rc1_darwin_amd64.zip"
-    sha256 "54aaf48e4e2daa5407b8d96da4c4e84305e77579b9af118d0c8df4a2512e2bd7"
+    sha256 "8fe6b38c033a32082679282e64186a5000d1c91031ad26d4b99250ee0c33c693"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-rc2.rb
+++ b/Casks/terraform-0.15.0-rc2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-rc2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-rc2/terraform_0.15.0-rc2_darwin_amd64.zip"
-    sha256 "2fd60ccbd3d01fb5adb57863c8cb0df98e0743d6a7a9a38dffeea631cef95d9f"
+    sha256 "04a54c3dd8723cfe824ac6605bf013c147872a228736564b79eb20799e1800a9"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0.rb
+++ b/Casks/terraform-0.15.0.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0/terraform_0.15.0_darwin_amd64.zip"
-    sha256 "96537262e38008a421d329ce51c1bc2a1926f0b4e68270c92a81a8a42fa2c513"
+    sha256 "394137bff715926be15b27abc867409b81a67c10efe8179a3298bb5cff4d8e61"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.1.rb
+++ b/Casks/terraform-0.15.1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.1/terraform_0.15.1_darwin_amd64.zip"
-    sha256 "dd7220e6a76e4c9555576c0500bea94c6a5cb65f286b3e74e8ea7cc34bbce5be"
+    sha256 "754543a004e9545ecbfb8a319a19cd734faea98c06b2345347077d9d1a0c21d9"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.2.rb
+++ b/Casks/terraform-0.15.2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.2/terraform_0.15.2_darwin_amd64.zip"
-    sha256 "d13b507e6f51fc58d880313775262954369fa6c98e163fa71e21b7d2a613c32a"
+    sha256 "ff5a2f187a2c0ba214ee0a4ab766a1c9025e5b4335b14da89c15cfe8b3bed2ca"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.3.rb
+++ b/Casks/terraform-0.15.3.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.3/terraform_0.15.3_darwin_amd64.zip"
-    sha256 "2cfa2f896aaf2c2b2fdadea6881f2796fe0d85ad0a42f471aadfb113bc32d11b"
+    sha256 "7ef568de653461b2b11b94498b79d737d0812e02093a1ef16061c489df63bc0f"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.4.rb
+++ b/Casks/terraform-0.15.4.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.4/terraform_0.15.4_darwin_amd64.zip"
-    sha256 "c7e413ad9d00a5ba177a32b0d46ff177239bd53a1aab67e7c5efad2e1e25978e"
+    sha256 "fe44710382dddb06b9fa113ed04018d022dae60ed44d9906a703b81cdfa6993a"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.5.rb
+++ b/Casks/terraform-0.15.5.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_darwin_amd64.zip"
-    sha256 "27d5ae2431240dff928e6483170b570782a8dd1a2b7c32ce1793097af1acb9bd"
+    sha256 "4ee2ed9b769426cc9f13bd26c133ee66c6046acffeef632ddf0ef66e3d36a981"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-1.0.0.rb
+++ b/Casks/terraform-1.0.0.rb
@@ -7,7 +7,7 @@ cask "terraform-1.0.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.0/terraform_1.0.0_darwin_amd64.zip"
-    sha256 "b67f5e25a73866b83880fd6fbc5e57add3ed893a31eda26b748aea4afc7255c4"
+    sha256 "2051ba2647b343ebac70108d059d85b6c66f3213d23091ce36f898abf019833f"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-1.0.1.rb
+++ b/Casks/terraform-1.0.1.rb
@@ -7,7 +7,7 @@ cask "terraform-1.0.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.1/terraform_1.0.1_darwin_amd64.zip"
-    sha256 "32c5b3123bc7a4284131dbcabd829c6e72f7cc4df7a83d6e725eb97905099317"
+    sha256 "06e796fb25c0ef089f48efbf7384cd1844c094222a4d3aeed6f4470932af9b6c"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-1.0.10.rb
+++ b/Casks/terraform-1.0.10.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.10" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.10/terraform_1.0.10_darwin_amd64.zip"
-    sha256 "e7595530a0dcdaec757621cbd9f931926fd904b1a1e5206bf2c9db6b73cee04d"
+    sha256 "a935053f20f4f38bee225fe91547457f1bc0de1aef6ac225a2460e15b72b0c83"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.10/terraform_1.0.10_darwin_arm64.zip"
-    sha256 "eecea1343888e2648d5f7ea25a29494fd3b5ecde95d0231024414458c59cb184"
+    sha256 "430c08fe7c5b6d965fb60690cebd79ddab94f4c6b9fab851af3a827dbc8a5e59"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.11.rb
+++ b/Casks/terraform-1.0.11.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.11" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_darwin_amd64.zip"
-    sha256 "92f2e7eebb9699e23800f8accd519775a02bd25fe79e1fe4530eca123f178202"
+    sha256 "5b6771c87f3febde756baa132d38a67fcac284291a1f88918a58a41d879d2558"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_darwin_arm64.zip"
-    sha256 "0f38af81641b00a2cbb8d25015d917887a7b62792c74c28d59e40e56ce6f265c"
+    sha256 "435cc512332c28c38c98cda11a2ef3670564cfc85ba4e6fe0a73462713799f9e"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.2.rb
+++ b/Casks/terraform-1.0.2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.2/terraform_1.0.2_darwin_amd64.zip"
-    sha256 "90e58796d84db0a16b5ad40140182061533c38210680980e099812c43b43ff7a"
+    sha256 "1c173ba93d8d6f00b3bd8908c0a1de6fd3a04c2ba4d6ff5f3361e0b56d139154"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.2/terraform_1.0.2_darwin_arm64.zip"
-    sha256 "eace5976af85f9eaf87ac20f6b6899562b8f18500af2fe4eee9e20b61d510b99"
+    sha256 "a5d03ea237f838d87396a8a53f42bc490687c8aa1283b830a0604e1e1bd54d31"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.3.rb
+++ b/Casks/terraform-1.0.3.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.3/terraform_1.0.3_darwin_amd64.zip"
-    sha256 "1de66203cf7f62ad990b6d8b583bc2caaadf8594150323f4d632a869448b85b9"
+    sha256 "2a8be22018464e981461f0ad1296946d97d6d85b366565eea46c545ded86bc24"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.3/terraform_1.0.3_darwin_arm64.zip"
-    sha256 "bf330b9d9bf24e87abf155de3828be2afa5a61d07df4d8cfe3d61e32bf71e687"
+    sha256 "134bb5581b091c8efe45f61eebd301aca9ff7b0c7491a254287cd0411dfe7a93"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.4.rb
+++ b/Casks/terraform-1.0.4.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.4/terraform_1.0.4_darwin_amd64.zip"
-    sha256 "cf7c7750c6380a12d6a4534c63844c803f14f5c5a8f71e32f7ad237ae81ae7a9"
+    sha256 "a4c40903d351f621f9640316f91efb6294cd53be1f8bec9314c8298f5248af01"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.4/terraform_1.0.4_darwin_arm64.zip"
-    sha256 "8b0a06a75fc6ae50cb75d2a3fb64d66fbe443bcda6d12d9e637cd3a701a29567"
+    sha256 "fcf5959566d5fd48acd7846d497be1cead90adf333fdf951649730127281815d"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.5.rb
+++ b/Casks/terraform-1.0.5.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.5/terraform_1.0.5_darwin_amd64.zip"
-    sha256 "ae0b07ba099d3d9241e5e8bcdfc88ada8fcbbe302cb1d8f822da866a25e55330"
+    sha256 "c62492495b455e6877359c01710c6c063c00c21b0abbd593ce3a2b6aa2605daa"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.5/terraform_1.0.5_darwin_arm64.zip"
-    sha256 "3de4b9f167392622ef49d807e438a166e6c86c631afa730ff3189cf72cc950e2"
+    sha256 "19b842a67a0f85b79c67cce604091ef2c87946c6d469d7c654751dc084c484d0"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.6.rb
+++ b/Casks/terraform-1.0.6.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.6" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.6/terraform_1.0.6_darwin_amd64.zip"
-    sha256 "3a97f2fffb75ac47a320d1595e20947afc8324571a784f1bd50bd91e26d5648c"
+    sha256 "a6066c152a8a48f8d23ca63a3b095680247f7003ad5145b905c3791db76fbc44"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.6/terraform_1.0.6_darwin_arm64.zip"
-    sha256 "aaff1eccaf4099da22fe3c6b662011f8295dad9c94a35e1557b92844610f91f3"
+    sha256 "6c54f8efe20d801066e7a3c0cd0d0b828e7e6bf6e3b820fd9435b4e8711f52aa"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.7.rb
+++ b/Casks/terraform-1.0.7.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.7/terraform_1.0.7_darwin_amd64.zip"
-    sha256 "80ae021d6143c7f7cbf4571f65595d154561a2a25fd934b7a8ccc1ebf3014b9b"
+    sha256 "909ca6950538a8a93c8d99c990b99b4a63285aadc57a7ec7d3b60aa0859fdc2c"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.7/terraform_1.0.7_darwin_arm64.zip"
-    sha256 "cbab9aca5bc4e604565697355eed185bb699733811374761b92000cc188a7725"
+    sha256 "014b781faf36bfe55ccb6c98e51b46ab6ef006890249a122bdeca0b208bf5396"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.8.rb
+++ b/Casks/terraform-1.0.8.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.8" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.8/terraform_1.0.8_darwin_amd64.zip"
-    sha256 "e2493c7ae12597d4a1e6437f6805b0a8bcaf01fc4e991d1f52f2773af3317342"
+    sha256 "1f36f77b59354ac398b8da33f903b1fa6d367dc7794a00f3b19729547bb8eca7"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.8/terraform_1.0.8_darwin_arm64.zip"
-    sha256 "9f0e1366484748ecbd87c8ef69cc4d3d79296b0e2c1a108bcbbff985dbb92de8"
+    sha256 "83dbd3b7119dbdc631e52664d8fcff2ae891fee851757ab3dc4df395c0eecf2d"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.9.rb
+++ b/Casks/terraform-1.0.9.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.9" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.9/terraform_1.0.9_darwin_amd64.zip"
-    sha256 "fb791c3efa323c5f0c2c36d14b9230deb1dc37f096a8159e718e8a9efa49a879"
+    sha256 "09d11c9867fce95f567c2ee285ad6883206b75220f39eef834c8592e7a5a2c39"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.9/terraform_1.0.9_darwin_arm64.zip"
-    sha256 "aa5cc13903be35236a60d116f593e519534bcabbb2cf91b69cae19307a17b3c0"
+    sha256 "f963b2e1ae5338a24e6f53e85f46b66e44e9227665cd56bafe659be2a517c39d"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20210616.rb
+++ b/Casks/terraform-1.1.0-alpha20210616.rb
@@ -7,7 +7,7 @@ cask "terraform-1.1.0-alpha20210616" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210616/terraform_1.1.0-alpha20210616_darwin_amd64.zip"
-    sha256 "941fbe1607ed501b278a9e4c42fb8c5dc11366aa09f5c30139bb1a209c4c2c6c"
+    sha256 "e7f82bb8769501e8794ec3b82f75243827605a64b456893427529215492ba622"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-1.1.0-alpha20210630.rb
+++ b/Casks/terraform-1.1.0-alpha20210630.rb
@@ -7,7 +7,7 @@ cask "terraform-1.1.0-alpha20210630" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210630/terraform_1.1.0-alpha20210630_darwin_amd64.zip"
-    sha256 "e1aad1616af609c2c87ccfe6d617c698a44abd1b0147afc0a1958a08bd4c2c9e"
+    sha256 "efe9cd45371847e46f3e416e28b8f0903b94736e757b3ece487c2cfa093355ec"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-1.1.0-alpha20210714.rb
+++ b/Casks/terraform-1.1.0-alpha20210714.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20210714" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210714/terraform_1.1.0-alpha20210714_darwin_amd64.zip"
-    sha256 "e35af55d525ab8c18ed880b2875caf280fb720b3d845f23021e7c0efb07048b8"
+    sha256 "91e25a3f563a34a69ba7345631ef5490d78abc6d087cb08a8544e12102abe802"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210714/terraform_1.1.0-alpha20210714_darwin_arm64.zip"
-    sha256 "63524ccb1ceca43180205ba15e4d5af6831ddfb1797e93d7a0e583f56962968c"
+    sha256 "2b22c319b7b1265e5ff1d27840395cbb020831110ddfbc2c03372f2fcc7d9317"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20210728.rb
+++ b/Casks/terraform-1.1.0-alpha20210728.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20210728" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210728/terraform_1.1.0-alpha20210728_darwin_amd64.zip"
-    sha256 "16f1d4e53b29dacc61184c8e52217c6f8c1197b3803a698cdc2ed1848a1b20f6"
+    sha256 "bbdfd6588598b96273f1c79f3c67ceafdbf0095f58bfe8abf5cfeae5650387a8"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210728/terraform_1.1.0-alpha20210728_darwin_arm64.zip"
-    sha256 "3de8ab1cff4e8db772ba4177e3cf9b25957f1aea19517f7a70718c18f0ccc7f9"
+    sha256 "261123d44899baaa8147a97978651b41d7f3b5d8f43f470ee01e0e16bb4b38a9"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20210811.rb
+++ b/Casks/terraform-1.1.0-alpha20210811.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20210811" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210811/terraform_1.1.0-alpha20210811_darwin_amd64.zip"
-    sha256 "fd2c4c8de79d7f1de30450f568996324ce68b9f07474eec14ada5112d7f80f5e"
+    sha256 "5382962ea627602a94018289ae3485eea66ee659b148854c39c6b3254e5b8c41"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210811/terraform_1.1.0-alpha20210811_darwin_arm64.zip"
-    sha256 "00de1719528bad276ba987f0d41cddade327555d7626a9b32a7745e16ce02b53"
+    sha256 "cc415c7810cd7f0f3865261afbdc162b77ef330bd8e9c6df27ac9a4cd1405b5a"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20210908.rb
+++ b/Casks/terraform-1.1.0-alpha20210908.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20210908" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210908/terraform_1.1.0-alpha20210908_darwin_amd64.zip"
-    sha256 "1ab3aa88a42557af41bd9412f14335479785e36af95408a75c0b3bf0af867a27"
+    sha256 "367b1f8da46936b9155d3351acc5e1bab4189d38cfe24f24182ec2c0350e8e4d"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210908/terraform_1.1.0-alpha20210908_darwin_arm64.zip"
-    sha256 "cecb24cfd7583a581bb45a46bdfc6617c2afd199ffd78754d903eef883333498"
+    sha256 "d9bbca900f4a09708766a31088947f47a0645d64f983b3fd039d2c2e920289c5"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20210922.rb
+++ b/Casks/terraform-1.1.0-alpha20210922.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20210922" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210922/terraform_1.1.0-alpha20210922_darwin_amd64.zip"
-    sha256 "22f9ddf073127d051e275b674a24cba2e3034f7e13df08ac8da73bc980c82944"
+    sha256 "11a1cfc4d9618cb6d06ad1468c4409df1673c1fb1a35e07d557c43d86f856dd6"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210922/terraform_1.1.0-alpha20210922_darwin_arm64.zip"
-    sha256 "49698f86bb2dd8c58c7e028105890d631f3c705ba210c0719b1e50b8a85a5501"
+    sha256 "fd9e3b693e61fe7bc796735ad2792fbff600e615c972446a0cda871a356190d8"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20211006.rb
+++ b/Casks/terraform-1.1.0-alpha20211006.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20211006" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20211006/terraform_1.1.0-alpha20211006_darwin_amd64.zip"
-    sha256 "4f5ca3423ca5d3bd27f7006b07a6259132c2a9fc0d0809736b8509847b987a07"
+    sha256 "71de072c22f3a546e76c5ab93bc4a8ec0190eb201dde14a7c73fe77f229644e1"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20211006/terraform_1.1.0-alpha20211006_darwin_arm64.zip"
-    sha256 "b4225ec2ca33ca4086be9b90066f4b93df987dff924234ea20f612a756579099"
+    sha256 "6aae75e171b6a06172ecc1c077a207a552951ff10f593954472cb5791a3d15d7"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20211020.rb
+++ b/Casks/terraform-1.1.0-alpha20211020.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20211020" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20211020/terraform_1.1.0-alpha20211020_darwin_amd64.zip"
-    sha256 "16686005a31b8404f5baedb260ebb11186868ce6c42f345b45e19b83e170f9c1"
+    sha256 "c86d0aa04c3dc85a7e41e006195041424527ff61b7ec75ff8df78a1d531661e3"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20211020/terraform_1.1.0-alpha20211020_darwin_arm64.zip"
-    sha256 "282d76d3c33b2e9bf94212a2485fe5a31fc1a4e6d6339ac6cfa923db001edb7b"
+    sha256 "30099d8ff71d4582e7ce96cef7cd5c9ccf3ac5090f66e1dc6cb44742de0aa48e"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20211029.rb
+++ b/Casks/terraform-1.1.0-alpha20211029.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20211029" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20211029/terraform_1.1.0-alpha20211029_darwin_amd64.zip"
-    sha256 "ab58023b6daa9fd6e5f07282ab48ebd6ad0c5d240224c237f6bf8355fb91574e"
+    sha256 "7b78c9f29ebac6e17af979654a1bf84901a7759c4f30c7ded88313d08abe98c7"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20211029/terraform_1.1.0-alpha20211029_darwin_arm64.zip"
-    sha256 "3cf2ba01b18d20fe80ac327be61270aca61fc1e50a884734226639122b1738d2"
+    sha256 "16ed907ee22a180a74558794cae3d46b39a66523fea69d159fabbb0e4c088e89"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-beta1.rb
+++ b/Casks/terraform-1.1.0-beta1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-beta1/terraform_1.1.0-beta1_darwin_amd64.zip"
-    sha256 "302aebb4e308d95bb6dc7307d109b7f4805d953ec0b331f7c2a643a59f2046bd"
+    sha256 "42ae96bc9a9035b4a579ea2ba540a3d98e0e2c9f09427cebeb261d7cfe3423e7"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-beta1/terraform_1.1.0-beta1_darwin_arm64.zip"
-    sha256 "4b94db55087bb167e8b50ba949fceb1bbe9933f1d743768eadf8e55dc86d7061"
+    sha256 "1fd3b6943291dcd65d994e1f5ece54483cc21a7c021bebc6a58e1d02947b2dd7"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-beta2.rb
+++ b/Casks/terraform-1.1.0-beta2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-beta2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-beta2/terraform_1.1.0-beta2_darwin_amd64.zip"
-    sha256 "851347d7777c4ed874ff7a321a7cbd8478bd323edf204783b35d00f077a8c826"
+    sha256 "1c49422be110b5518c612968aa6b20e83a8fb74a88dd6b8fee2774b93e6cec9c"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-beta2/terraform_1.1.0-beta2_darwin_arm64.zip"
-    sha256 "7b0a670952ea91d507169be4e6b34b0efa318f8d8201b6eb4d81e48aad423452"
+    sha256 "03b5e40d214c885629c917571982350cf8a084a416d924d89b6c035b1dff3e00"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-rc1.rb
+++ b/Casks/terraform-1.1.0-rc1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-rc1/terraform_1.1.0-rc1_darwin_amd64.zip"
-    sha256 "507605a8e3f73f006d5446ba656d69562184bf1631fb96dce3b0abde73dba635"
+    sha256 "cd140f8bc90aeb9c349d06655c4bd7fa6bb761a0fac774eaf81412dd4b4d6015"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-rc1/terraform_1.1.0-rc1_darwin_arm64.zip"
-    sha256 "ccae178553fba390a8a8c73e33285581f9bf510d56010ef7fbd67d067e1f92a8"
+    sha256 "1482dd6a92332bed861a8751da35b79e5e1ba28e399720cec668920b5bf0b280"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0.rb
+++ b/Casks/terraform-1.1.0.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0/terraform_1.1.0_darwin_amd64.zip"
-    sha256 "6fb2af160879d807291980642efa93cc9a97ddf662b17cc3753065c974a5296d"
+    sha256 "37ea10c6c24152e1e23ab1163a42cba93f3facd8a4b65a569d72373578f2151f"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0/terraform_1.1.0_darwin_arm64.zip"
-    sha256 "f69e0613f09c21d44ce2131b20e8b97909f3fc7aa90c443639475f5e474a22ec"
+    sha256 "d1b17c019e6b0cfc4d286c6cd42b051278be91064d117bea3708a9396e39642e"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.1.rb
+++ b/Casks/terraform-1.1.1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.1/terraform_1.1.1_darwin_amd64.zip"
-    sha256 "85fa7c90359c4e3358f78e58f35897b3e466d00c0d0648820830cac5a07609c3"
+    sha256 "2850e6deb502bb34deb3e7ba0b45d302c017fff509d0e2ec39f99c1172f2bd37"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.1/terraform_1.1.1_darwin_arm64.zip"
-    sha256 "9cd8faf29095c57e30f04f9ca5fa9105f6717b277c65061a46f74f22f0f5907e"
+    sha256 "fcaf92a9a9e6106d19b1bed54671809639946688ce02ad35b878802d01031bc2"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.2.rb
+++ b/Casks/terraform-1.1.2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.2/terraform_1.1.2_darwin_amd64.zip"
-    sha256 "214da2e97f95389ba7557b8fcb11fe05a23d877e0fd67cd97fcbc160560078f1"
+    sha256 "18c8b539c4e319c151d94a9e068be3cd33323d42e1dc8065c7acbca9843fa2d5"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.2/terraform_1.1.2_darwin_arm64.zip"
-    sha256 "39e28f49a753c99b5e2cb30ac8146fb6b48da319c9db9d152b1e8a05ec9d4a13"
+    sha256 "782854af8366e15ab2140238133e85f0b0faf435e35ec352aabdf2dd6d09a744"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.3.rb
+++ b/Casks/terraform-1.1.3.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.3/terraform_1.1.3_darwin_amd64.zip"
-    sha256 "c54022e514a97e9b96dae24a3308227d034989ecbafb65e3293eea91f2d5edfb"
+    sha256 "6c6e5503b8a94286a6a883e3ff98777a9e372783bd1929db1377f70e9ce262c2"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.3/terraform_1.1.3_darwin_arm64.zip"
-    sha256 "856e435da081d0a214c47a4eb09b1842f35eaa55e7ef0f9fa715d4816981d640"
+    sha256 "ebb664e8840e029f9112c7ce58cb4857a99585cdfef8cdda6490e8851ca88bc5"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.4.rb
+++ b/Casks/terraform-1.1.4.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.4/terraform_1.1.4_darwin_amd64.zip"
-    sha256 "c2b2500835d2eb9d614f50f6f74c08781f0fee803699279b3eb0188b656427f2"
+    sha256 "ec38bbc7a0153fe15cecc29895cbf0c4fb22228e8408538af99af59414f14b6c"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.4/terraform_1.1.4_darwin_arm64.zip"
-    sha256 "a753e6cf402beddc4043a3968ff3e790cf50cc526827cda83a0f442a893f2235"
+    sha256 "d13e93873f3831eb221391e5ad4d1da37becea5476a88663141325378613829c"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.5.rb
+++ b/Casks/terraform-1.1.5.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.5/terraform_1.1.5_darwin_amd64.zip"
-    sha256 "7d4dbd76329c25869e407706fed01213beb9d6235c26e01c795a141c2065d053"
+    sha256 "7b07795ac98ed7efb7aae509013cd99c83a4f9154c8a11adb57b7786716038f1"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.5/terraform_1.1.5_darwin_arm64.zip"
-    sha256 "723363af9524c0897e9a7d871d27f0d96f6aafd11990df7e6348f5b45d2dbe2c"
+    sha256 "4e5e2746a984a9ba80f9277fd80a08db852b9303b0fabaa3288247a16e7b2e37"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.6.rb
+++ b/Casks/terraform-1.1.6.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.6" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.6/terraform_1.1.6_darwin_amd64.zip"
-    sha256 "bbfc916117e45788661c066ec39a0727f64c7557bf6ce9f486bbd97c16841975"
+    sha256 "dc515ad0d44c0543cc3e43e1139ecc1dab37536f5bce91eb63f2b4be483b84e4"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.6/terraform_1.1.6_darwin_arm64.zip"
-    sha256 "dddb11195fc413653b98e7a830ec7314f297e6c22575fc878f4ee2287a25b4f5"
+    sha256 "065ab7df89e8ee64353746400469e6bad540c177f546efba40fdd0c04c9ca9f6"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.7.rb
+++ b/Casks/terraform-1.1.7.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_darwin_amd64.zip"
-    sha256 "5e7e939e084ae29af7fd86b00a618433d905477c52add2d4ea8770692acbceac"
+    sha256 "1929033b24e2ab21f2d28709a13e19b5c7e8ac9509daf8a87d200fd3a47cce3d"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_darwin_arm64.zip"
-    sha256 "a36b6e2810f81a404c11005942b69c3d1d9baa8dd07de6b1f84e87a67eedb58f"
+    sha256 "d457409a895cb5611e38425a8fc0804b782deec698cc4b9bbbf290bc67186d0f"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.8.rb
+++ b/Casks/terraform-1.1.8.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.8" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_darwin_amd64.zip"
-    sha256 "29ad0af72d498a76bbc51cc5cb09a6d6d0e5673cbbab6ef7aca57e3c3e780f46"
+    sha256 "a8fb67020be31b32728ecb08ddb9e2873cda6a587574761ab3d90cf447700e85"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_darwin_arm64.zip"
-    sha256 "d6fefdc27396a019da56cce26f7eeea3d6986714cbdd488ff6a424f4bca40de8"
+    sha256 "e5eb657f9e38be1c3934428a7021cf89fa51aba0e86321b4ccc6e76b971bd3b4"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.9.rb
+++ b/Casks/terraform-1.1.9.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.9" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_darwin_amd64.zip"
-    sha256 "c902b3c12042ac1d950637c2dd72ff19139519658f69290b310f1a5924586286"
+    sha256 "26afa7cda355fbf32a2b4cfd9122a49132f1b68337691b91f05caa0b1023c388"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_darwin_arm64.zip"
-    sha256 "918a8684da5a5529285135f14b09766bd4eb0e8c6612a4db7c121174b4831739"
+    sha256 "80a230b56853f0fd50e12006c0d527da6a7f2e9974f25f7d372abfa2761ee3a3"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.0-alpha-20220328.rb
+++ b/Casks/terraform-1.2.0-alpha-20220328.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.0-alpha-20220328" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.0-alpha-20220328/terraform_1.2.0-alpha-20220328_darwin_amd64.zip"
-    sha256 "f13a13b4656e41e6ca18e5ea894707219ebf4d9dc061a02eaebffc3ec05d26e8"
+    sha256 "1b3a771235ab21e519c11f1a57aebce894938927d02c10d5cc75bc7022c405e8"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.0-alpha-20220328/terraform_1.2.0-alpha-20220328_darwin_arm64.zip"
-    sha256 "91d9760779d58e9b0f2089858241afa80a24f476187a392affcbf594e62b3c81"
+    sha256 "8dfcddd36d842194fcc79def3da1c9224abc982b60d9438710828b93f03ad660"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.0-alpha20220413.rb
+++ b/Casks/terraform-1.2.0-alpha20220413.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.0-alpha20220413" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.0-alpha20220413/terraform_1.2.0-alpha20220413_darwin_amd64.zip"
-    sha256 "65220850ab69b2b953526a15e7a9865ca36afc1c4161fd26694327c797697a6d"
+    sha256 "8642ee1d2cfea914f5ed982b2839c34d693d66b7e410a94774aaacd1934ba0e6"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.0-alpha20220413/terraform_1.2.0-alpha20220413_darwin_arm64.zip"
-    sha256 "479b394738050446235784288879190fadad9e8f463b512d351c22830d9399d9"
+    sha256 "4f1dd666857728915b91e3681f536945028fe5c3517a820fae503d39d0d74b38"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.0-beta1.rb
+++ b/Casks/terraform-1.2.0-beta1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.0-beta1/terraform_1.2.0-beta1_darwin_amd64.zip"
-    sha256 "d3bb52ecd91f19f5bd40a8049648cf836808155c47adc4a2140193a1874153be"
+    sha256 "10ec4ede5a27b00920b430240348017bbf4c0c72d0cbdbfaa72f8bc8eca453c7"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.0-beta1/terraform_1.2.0-beta1_darwin_arm64.zip"
-    sha256 "1b726e9d6318a03c67f6b2437d7024954f40a13d254d032498e182860094ecae"
+    sha256 "dd3eb0103183e19d1370e6bad82bcbf4158efa658cb65fb0065e2e975812b76c"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.0-rc1.rb
+++ b/Casks/terraform-1.2.0-rc1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.0-rc1/terraform_1.2.0-rc1_darwin_amd64.zip"
-    sha256 "bd2c639edb2f607b82ee6c72b0d8d9e51c201440f6b87ec25a5fd6b564d3a9a9"
+    sha256 "028f8c331ea53946b987556c6e7544efc2bd8c23d6fa86ee851102b84b888c61"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.0-rc1/terraform_1.2.0-rc1_darwin_arm64.zip"
-    sha256 "42c742deed49595dcf5a445892343462ff6292cb6bd70ce2bea9e1ee99c87cf9"
+    sha256 "14fa938ef5306b07e9b164998e763fd5ead9d3ff012d1f0f2e162cacfaeabfde"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.0-rc2.rb
+++ b/Casks/terraform-1.2.0-rc2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.0-rc2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.0-rc2/terraform_1.2.0-rc2_darwin_amd64.zip"
-    sha256 "7563d6c8cd17ef0e6116c29c56f86e06adcb204e7208b06f1961ea55268a92ff"
+    sha256 "12e9dbf25d532e3d7ff422f90eca5118de970e24e28feb998e6e37fdc3cedf3c"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.0-rc2/terraform_1.2.0-rc2_darwin_arm64.zip"
-    sha256 "eb624f4cd5adcdd2cf75261bb686649b4cca916e1b4546b518448d68f8c36f9a"
+    sha256 "149e813432378cb228b380b8ff9e46185fdba4193810bfd8f51dfce9317ca85e"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.0.rb
+++ b/Casks/terraform-1.2.0.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.0/terraform_1.2.0_darwin_amd64.zip"
-    sha256 "f608b1fee818988d89a16b7d1b6d22b37cc98892608c52c22661ca6cbfc3d216"
+    sha256 "cd60e3c04eccfceb655c60b0b1fa42cd07b23ecfabcbeebeab60c46b2b693dbf"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.0/terraform_1.2.0_darwin_arm64.zip"
-    sha256 "d4df7307bad8c13e443493c53898a7060f77d661bfdf06215b61b65621ed53e9"
+    sha256 "a35b308a05736c45a134ea52ead712a9cc91c4cdcfb859d02951190217ef26ef"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.1.rb
+++ b/Casks/terraform-1.2.1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.1/terraform_1.2.1_darwin_amd64.zip"
-    sha256 "d7c9a677efb22276afdd6c7703cbfee87d509a31acb247b96aa550a35154400a"
+    sha256 "f9cf601b455df91fa8894d5f8169e3901cb562b7579c76d26bf429d03dad1437"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.1/terraform_1.2.1_darwin_arm64.zip"
-    sha256 "96e3659e89bfb50f70d1bb8660452ec433019d00a862d2291817c831305d85ea"
+    sha256 "46adfff9135f43635b2077ec642429a4ec3201169430c8de97ae31884ab40b74"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.2.rb
+++ b/Casks/terraform-1.2.2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.2/terraform_1.2.2_darwin_amd64.zip"
-    sha256 "bd224d57718ed2b6e5e3b55383878d4b122c6dc058d65625605cef1ace9dcb25"
+    sha256 "1568b1f7c22d1612d9608b28433506d3d28aaed11ab2c69e6c104855f3e00a55"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.2/terraform_1.2.2_darwin_arm64.zip"
-    sha256 "4750d46e47345809a0baa3c330771c8c8a227b77bec4caa7451422a21acefae5"
+    sha256 "78097a2e9e25b78cfa7a001eb5c4c27f13097051e6a3f340699febdbd12f62fa"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.3.rb
+++ b/Casks/terraform-1.2.3.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.3/terraform_1.2.3_darwin_amd64.zip"
-    sha256 "2962b0ebdf6f431b8fb182ffc1d8b582b73945db0c3ab99230ffc360d9e297a2"
+    sha256 "667fb8897a3db7af97457df2300f628916ac41c0283d1b4d4816c73c04123e36"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.3/terraform_1.2.3_darwin_arm64.zip"
-    sha256 "601962205ad3dcf9b1b75f758589890a07854506cbd08ca2fc25afbf373bff53"
+    sha256 "05a6dcbd285723d63a7e0ad63c5bc25da58888f32d5f4cfc3f2e057f1d3080ae"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.4.rb
+++ b/Casks/terraform-1.2.4.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.4/terraform_1.2.4_darwin_amd64.zip"
-    sha256 "3e04343620fb01b8be01c8689dcb018b8823d8d7b070346086d7df22cc4cd5e6"
+    sha256 "4440024c9bd30bfa265eccf9822a41c5c9eb7b237d393f995bb3361db9c0c652"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.4/terraform_1.2.4_darwin_arm64.zip"
-    sha256 "e596dcdfe55b2070a55fcb271873e86d1af7f6b624ffad4837ccef119fdac97a"
+    sha256 "0c3ff7c40441efc668705f7113ba4e16bc04aacb58fe0e2053432a27457afc03"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.5.rb
+++ b/Casks/terraform-1.2.5.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.5/terraform_1.2.5_darwin_amd64.zip"
-    sha256 "d196f94486e54407524a0efbcb5756b197b763863ead2e145f86dd6c80fc9ce8"
+    sha256 "6e109f82f15e5879cf003da75021f94266e54943fdfed4182a309e1159bc0e5c"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.5/terraform_1.2.5_darwin_arm64.zip"
-    sha256 "77dd998d26e578aa22de557dc142672307807c88e3a4da65d8442de61479899f"
+    sha256 "0e322ffcd0d680a43788228a4e565379a7a6735a0d5fa4ae688cf89b415e020e"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.6.rb
+++ b/Casks/terraform-1.2.6.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.6" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.6/terraform_1.2.6_darwin_amd64.zip"
-    sha256 "94d1efad05a06c879b9c1afc8a6f7acb2532d33864225605fc766ecdd58d9888"
+    sha256 "31a228531d9cbcd964ca1d5eb0e0d9a1484619627503dcc1ae2a2c63d50ae975"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.6/terraform_1.2.6_darwin_arm64.zip"
-    sha256 "452675f91cfe955a95708697a739d9b114c39ff566da7d9b31489064ceaaf66a"
+    sha256 "d8e13e67f7303f68ca66e882f715d2af80d0124c9511b78f5ce799236654dc8e"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.7.rb
+++ b/Casks/terraform-1.2.7.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.7/terraform_1.2.7_darwin_amd64.zip"
-    sha256 "acc781e964be9b527101b00eb6e7e63e7e509dd1355ff8567b80d0244c460634"
+    sha256 "b413d0d3346370a741205fcfa180a4043e9c247ff0189708cf5a655373a1574a"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.7/terraform_1.2.7_darwin_arm64.zip"
-    sha256 "e4717057e1cbb606f1e089261def9a17ddd18b78707d9e212c768dc0d739a220"
+    sha256 "dd2d8143482f01e725a36f3864b78f518cae25e9480e5aeb1985637e65d5e56d"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.8.rb
+++ b/Casks/terraform-1.2.8.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.8" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.8/terraform_1.2.8_darwin_amd64.zip"
-    sha256 "0f8eecc764b57a938aa115a3ce2baa0d245479f17c28a4217bcf432ee23c2c5d"
+    sha256 "5bad72d8dfca1cddaecfdc51858f035808ce268c201bee780982fbd8ce5814bb"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.8/terraform_1.2.8_darwin_arm64.zip"
-    sha256 "d6b900682d33aff84f8f63f69557f8ea8537218748fcac6f12483aaa46959a14"
+    sha256 "0affbfe6f8f791d6fb98ab5f91e975b0b1255dee9f172faee3ff6ab05c45a024"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.9.rb
+++ b/Casks/terraform-1.2.9.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.9" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_darwin_amd64.zip"
-    sha256 "46206e564fdd792e709b7ec70eab1c873c9b1b17f4d33c07a1faa9d68955061b"
+    sha256 "2c4d2b425a0680c6a4d65601a5f42f8b5c23e4ccd3332cf649ce14eaa646b967"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_darwin_arm64.zip"
-    sha256 "e61195aa7cc5caf6c86c35b8099b4a29339cd51e54518eb020bddb35cfc0737d"
+    sha256 "91f51a352027f338b7673f23ee3c438ca8575933b7f58bfd7a92ffccf552158b"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-alpha20220608.rb
+++ b/Casks/terraform-1.3.0-alpha20220608.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-alpha20220608" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220608/terraform_1.3.0-alpha20220608_darwin_amd64.zip"
-    sha256 "f3ae274c586e3ca7c1dbaecf1c475ff70fe942de91caeb47540b39e906589d0c"
+    sha256 "ea5c01a73114461aaa57b33f99dbbe0e76ad9fd767f4954b18edade86f5e41b6"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220608/terraform_1.3.0-alpha20220608_darwin_arm64.zip"
-    sha256 "798d0b02ce243a59d4982fcc0a1d00ed9f3fcdd22cc194503866291f217047ee"
+    sha256 "f6972d9f59e48046e6711afbfaa78c0d62a5654572a26570968c88742cebf3a0"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-alpha20220622.rb
+++ b/Casks/terraform-1.3.0-alpha20220622.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-alpha20220622" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220622/terraform_1.3.0-alpha20220622_darwin_amd64.zip"
-    sha256 "81cf0bdef5d6cc90b3f9fb498abb53e029fe00c570bf6ba0b00d2d02ea60eaed"
+    sha256 "e43e825551dc5e1db5c0317e199df223247ea2bdb34ae848ace186e975e807b6"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220622/terraform_1.3.0-alpha20220622_darwin_arm64.zip"
-    sha256 "281373c9f7cef1b488436d5dcacbb578f056a655db5302a4cd36760fb538d002"
+    sha256 "342a902b19c83e3f1ffe875821aa74449b5142ca11406b76b00c9fef44391c4f"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-alpha20220706.rb
+++ b/Casks/terraform-1.3.0-alpha20220706.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-alpha20220706" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220706/terraform_1.3.0-alpha20220706_darwin_amd64.zip"
-    sha256 "06e3a1d8dce6854bd026a0fa669a78119be7bda3434996d8e8b9a1a496555c15"
+    sha256 "9f75c33f60b8578ae63139c2cd0891f98269a0601596625c0f2be5bc456d99e8"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220706/terraform_1.3.0-alpha20220706_darwin_arm64.zip"
-    sha256 "6d3e88fee2ce4084b3a59955a82743c7a2b0144913015d1374939d6ece3e085c"
+    sha256 "634d7bd3c5c6249d0ae9ce30ea173929be0ee0252e5233b5ad1bd32295f8fabb"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-alpha20220803.rb
+++ b/Casks/terraform-1.3.0-alpha20220803.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-alpha20220803" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220803/terraform_1.3.0-alpha20220803_darwin_amd64.zip"
-    sha256 "faa45834e3e9378650e7783bde03048472bf77fe48bfee0539de4f7cf9d0ab11"
+    sha256 "e745b07e19e5a58dac739d4f7f6945674d0c7f2fe2bde8d35ed214a2ffb657b5"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220803/terraform_1.3.0-alpha20220803_darwin_arm64.zip"
-    sha256 "0821f91c0b80f02d68bb9990c7e2ad125246b04bee8029404b34d33de304f40f"
+    sha256 "d772192d847a94c55faa116727786d71cdeb16bb5602c3f30b1ddfd9ec56dc6d"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-alpha20220817.rb
+++ b/Casks/terraform-1.3.0-alpha20220817.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-alpha20220817" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220817/terraform_1.3.0-alpha20220817_darwin_amd64.zip"
-    sha256 "254ceea0ceda640289038b8d2e79e8609b72faee990859ffbc1700c385dd1e56"
+    sha256 "85bd822b98781c65aaa570acc7be58c9d2d50981f0bfd7370395ee98dcfce75a"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220817/terraform_1.3.0-alpha20220817_darwin_arm64.zip"
-    sha256 "b6186f4b1a3a057af66f793c9623282c227b2dd4ca890a7a5007ae0c71fd108a"
+    sha256 "06018d146f15436823cba72aa972f364e99a9c7b5f3958d2247412862abbd492"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-beta1.rb
+++ b/Casks/terraform-1.3.0-beta1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-beta1/terraform_1.3.0-beta1_darwin_amd64.zip"
-    sha256 "2f407536ec57a1c6ccb6936dee202e676c4d5f1bc085bcbf6a4e8fad1180d879"
+    sha256 "d1eee240f0a86681c0bd34bd77a1a8cbd726dd2e22835414913985aaff285cee"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-beta1/terraform_1.3.0-beta1_darwin_arm64.zip"
-    sha256 "3eecf0ac0d1d091f17c9dfedd3c0f7e45de79b30092fa84f0014094b288234df"
+    sha256 "953d6425b54c9722a79936d55df36bdf97ee2acab9d52817c02a5347be14ff8e"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-rc1.rb
+++ b/Casks/terraform-1.3.0-rc1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-rc1/terraform_1.3.0-rc1_darwin_amd64.zip"
-    sha256 "a4583ddee28cb4c3bcade0b093755c9894d56546753edd1765669e993b764f83"
+    sha256 "18d8c4a4384ecb11071e178ec58eeb1c82dde84793e7bf68a1e2ea2c3a8c46e5"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-rc1/terraform_1.3.0-rc1_darwin_arm64.zip"
-    sha256 "615c3c56077fafdc68786fd7732f176330381c838b380f1695b9861f6ee2505f"
+    sha256 "3b825cefa3b3a7a6c3e5f78b5a36a20aabda2a1fc0e7874e50d226d0c3773d9d"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0.rb
+++ b/Casks/terraform-1.3.0.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0/terraform_1.3.0_darwin_amd64.zip"
-    sha256 "6502dbcbd7d1a356fa446ec12c2859a9a7276af92c89ce3cef7f675a8582a152"
+    sha256 "11ef95dc03e282463751113a153a07ff1fc63b9c3682085907fb110b69d5a347"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0/terraform_1.3.0_darwin_arm64.zip"
-    sha256 "6a3512a1b1006f2edc6fe5f51add9a6e1ef3967912ecf27e66f22e70b9ad7158"
+    sha256 "377249d76423c4f51751083f502092525b2de0adc931930a2f5841554f64ff4e"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.1.rb
+++ b/Casks/terraform-1.3.1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.1/terraform_1.3.1_darwin_amd64.zip"
-    sha256 "5f5967e12e75a3ca1720be3eeba8232b4ba8b42d2d9e9f9664eff7a68267e873"
+    sha256 "2be5311db5199fa3d900422496fd5ff954fc852700511c1e9804fdddc06b43fa"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.1/terraform_1.3.1_darwin_arm64.zip"
-    sha256 "a525488cc3a26d25c5769fb7ffcabbfcd64f79cec5ebbfc94c18b5ec74a03b35"
+    sha256 "15a0d43c8458f628172151c2598bc8f4206a2a015c64a377d3dc6949cd605f13"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.2.rb
+++ b/Casks/terraform-1.3.2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.2/terraform_1.3.2_darwin_amd64.zip"
-    sha256 "edaed5a7c4057f1f2a3826922f3e594c45e24c1e22605b94de9c097b683c38bd"
+    sha256 "b5874e6a2b355f90331e0256737bbeeb85be59e477c32619555e98848b983765"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.2/terraform_1.3.2_darwin_arm64.zip"
-    sha256 "ff92cd79b01d39a890314c2df91355c0b6d6815fbc069ccaee9da5d8b9ff8580"
+    sha256 "4e186e1caadad1e86281cb44f552d12f39186ae2ffe5852a525582b62353bcfc"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.3.rb
+++ b/Casks/terraform-1.3.3.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_darwin_amd64.zip"
-    sha256 "e544aefb984fd9b19de250ac063a7aa28cbfdce2eda428dd2429a521912f6a93"
+    sha256 "3f9dcc89206f7503c7f52465a48a97eac7ed0b2daf70404f2b422e42b0064e42"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_darwin_arm64.zip"
-    sha256 "1850df7904025b20b26ac101274f30673b132adc84686178d3d0cb802be4597e"
+    sha256 "2fb68f9a4d1aadc55b10ddc56d07bbcf7a492b9e5c0525eb88e46abdf6eeb3b3"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.4.rb
+++ b/Casks/terraform-1.3.4.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.4/terraform_1.3.4_darwin_amd64.zip"
-    sha256 "03e0d7f629f28e2ea31ec2c69408b500f00eac674c613f7f1097536dcfa2cf6c"
+    sha256 "295de24b5f793192fa7aa02ff9e3a1c9486d14881a0a1f126a5ce4321ca8d8c4"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.4/terraform_1.3.4_darwin_arm64.zip"
-    sha256 "7b4401edd8de50cda97d76b051c3a4b1882fa5aa8e867d4c4c2770e4c3b0056e"
+    sha256 "a02c19942edd0c5b2b4ac73d08e8c1c28238895d8afd8e98a7dab80cc2a2d920"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.5.rb
+++ b/Casks/terraform-1.3.5.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.5/terraform_1.3.5_darwin_amd64.zip"
-    sha256 "6bf684dbc19ecbf9225f5a2409def32e5ef7d37af3899726accd9420a88a6bcd"
+    sha256 "d8b820f0ed8442819b9a8870efdd6bf54f1c5a392a278d7713fe0f1c05c4fdeb"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.5/terraform_1.3.5_darwin_arm64.zip"
-    sha256 "33b25ad89dedbd98bba09cbde69dcf9e928029f322ae9494279cf2c8ce47db89"
+    sha256 "6764387bb58ba0ac8c7dc9b3d2e93b97812ddd2b8e8ca56a930e7e2c601a3a12"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.6.rb
+++ b/Casks/terraform-1.3.6.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.6" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.6/terraform_1.3.6_darwin_amd64.zip"
-    sha256 "5ab98e2d9f3b908fd6422a0562e829cc17eb055c8e242427d16d0a13506d401b"
+    sha256 "1e0b39ebb6c8bc5aa1bb38a4bc7dc0719f812e55adb6d1c9af33bc2527bb3497"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.6/terraform_1.3.6_darwin_arm64.zip"
-    sha256 "f1c20b2180c982bdda8384b1316209d20fc55def4f0354ead7a2a8e04c89f54e"
+    sha256 "0df7916a7189939bfcd308e0c78b99bfd1ec5582d05aa109975837c29ceff700"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.7.rb
+++ b/Casks/terraform-1.3.7.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_darwin_amd64.zip"
-    sha256 "aa111cd80d84586697d1643c6c21452d34f70e5bc639e4106856f59382351397"
+    sha256 "b00465acc7bdef57ba468b84b9162786e472dc97ad036a9e3526dde510563e2d"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_darwin_arm64.zip"
-    sha256 "8860db524d1a51435cbed731902c7de1595348c09dd5b3a342024405c8e7ef74"
+    sha256 "6cda396999c9a27cb90c4902913c10ac0afe1bfceb957ed50a4298c5872979cf"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.4.0-alpha20221109.rb
+++ b/Casks/terraform-1.4.0-alpha20221109.rb
@@ -7,10 +7,10 @@ cask "terraform-1.4.0-alpha20221109" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.4.0-alpha20221109/terraform_1.4.0-alpha20221109_darwin_amd64.zip"
-    sha256 "537d012d01d07cfcf358e1351a017008bd2dd8f897f37fbfa8b255740415636b"
+    sha256 "98f4cbc43bd66b9d85476c4c61561a7b812346740fadea3276afa74a3ee4daeb"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.4.0-alpha20221109/terraform_1.4.0-alpha20221109_darwin_arm64.zip"
-    sha256 "2d8484526efe7692a98570b61eed760b2dd77755f3759cb7c8cf0b2335b5a3e9"
+    sha256 "7116338bc56f5eeaf7db07e6868a79f766bbda1eefeaa9510a1d2d19cb92ceea"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.4.0-alpha20221207.rb
+++ b/Casks/terraform-1.4.0-alpha20221207.rb
@@ -7,10 +7,10 @@ cask "terraform-1.4.0-alpha20221207" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.4.0-alpha20221207/terraform_1.4.0-alpha20221207_darwin_amd64.zip"
-    sha256 "fd6ae369b531dfce590ea5106164f10d546447727bb0982f6fefde07994536b0"
+    sha256 "4ccc37ca714d6068a5624ec1b05ec219548270673823c04299bdd17973faf4cf"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.4.0-alpha20221207/terraform_1.4.0-alpha20221207_darwin_arm64.zip"
-    sha256 "a0fda61123b2bc40273df7bcf45d46fa712977b6593b7aa94351ca14e9c48313"
+    sha256 "0fe42b84847d9d320417e51f6b9918a8e4ff6a2ce2e3dabc8aa6a86372847964"
   end
 
   depends_on arch: [:x86_64, :arm64]


### PR DESCRIPTION
Compared terraform_1.3.7_SHA256SUMS from https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_SHA256SUMS to the ones in Cask and they don't match. Same situation with 1.3.6, 1.3.5, 1.3.4, 1.3.3, 1.3.2, 1.3.1 and 1.3.0. I wonder if they have compiled these terraform versions with more recent golang versions or what is going on.