### PR TITLE
Update outdated shasums for most darwin releases

### DIFF
--- a/Casks/terraform-0.11.15-oci.rb
+++ b/Casks/terraform-0.11.15-oci.rb
@@ -7,7 +7,7 @@ cask "terraform-0.11.15-oci" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.11.15-oci/terraform_0.11.15-oci_darwin_amd64.zip"
-    sha256 "52e20f74001af262792ea379be3eb7f169420646e48514d063ffe2591a844821"
+    sha256 "e219eeee655797d485005014f3833ebfb5484423fa770cf462a03c36f3cfa359"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.11.15.rb
+++ b/Casks/terraform-0.11.15.rb
@@ -7,7 +7,7 @@ cask "terraform-0.11.15" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_darwin_amd64.zip"
-    sha256 "e98434b0d35c4ec058479148dd590d2bbf3e419fcc6db204522cc4b0bbd9ec25"
+    sha256 "9c3214dcaa277c3773d52d514a76959c82896a1661061b7e5f9523c38add10b7"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.10.rb
+++ b/Casks/terraform-0.12.10.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.10" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.10/terraform_0.12.10_darwin_amd64.zip"
-    sha256 "1a4f17da540d68c015d693f8a88dd873b514bdfe1d65dfbf6f7a0af3768c3104"
+    sha256 "70692a1221848c8a6f29972e89eaaf400ecc2aa33708b9ed14a17957e3845533"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.11.rb
+++ b/Casks/terraform-0.12.11.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.11" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.11/terraform_0.12.11_darwin_amd64.zip"
-    sha256 "8f54fa6256ec4c4a6a1e0094e39825fb7287ef4b4680d9a133ec6dda18b80e29"
+    sha256 "31c7451366605a9d6a6dc41ae0ab29ec186eebeed13e05349f578eaac7692596"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.12.rb
+++ b/Casks/terraform-0.12.12.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.12" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.12/terraform_0.12.12_darwin_amd64.zip"
-    sha256 "c97c51f40d2709143bbefdf7ac9130fc518a0ef337706e7ebdde36cc6056219e"
+    sha256 "abc3a0b5184259be2b9f744baae0d3709fae0e38112e36d35ff9debb43375e97"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.13.rb
+++ b/Casks/terraform-0.12.13.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.13" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.13/terraform_0.12.13_darwin_amd64.zip"
-    sha256 "ff0ca1bd75c64b0811d3c79d7cce23e9011426efc6851ba7b6c92b7ae1a4cfb4"
+    sha256 "77d9e73edccc9cc3c7b5e0f1c84a90f0f18b55359aff9181faf636c9fb14c15a"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.14.rb
+++ b/Casks/terraform-0.12.14.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.14" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.14/terraform_0.12.14_darwin_amd64.zip"
-    sha256 "ce2addedea513861c21158988a10ab3e15c20c19c9b67c2891ccf97cf87934d6"
+    sha256 "23de0d866199d0d305084c146969115318773921fcf22c1d78503bdafec4c44d"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.15.rb
+++ b/Casks/terraform-0.12.15.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.15" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.15/terraform_0.12.15_darwin_amd64.zip"
-    sha256 "b3aa81bd0dd2b5a3c89a82afa7b32291bc6b09e2cdbc4909bb7da14ff9da4d24"
+    sha256 "4f238094e332c16ee7bcffe234ae71cf355eb7d54f4ae9f531af0e2d374cecbc"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.16.rb
+++ b/Casks/terraform-0.12.16.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.16" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.16/terraform_0.12.16_darwin_amd64.zip"
-    sha256 "c75ad22dd0d512531e4fed2e4e6ba6afc294ab43d33e01e144d63acfff0d8b3c"
+    sha256 "8d3db354320078e0ceb0beec97ca1a0934378ef8ede28e2fe76481c171267762"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.17.rb
+++ b/Casks/terraform-0.12.17.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.17" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.17/terraform_0.12.17_darwin_amd64.zip"
-    sha256 "b0a3fe53880b074cfb173b492cf6891ff3cd2614589570af04a73a64cc12deb5"
+    sha256 "130235cad547ab0f9849dedbd020528e0c76798bd53528a3cd63c7ce51290e8f"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.18.rb
+++ b/Casks/terraform-0.12.18.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.18" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.18/terraform_0.12.18_darwin_amd64.zip"
-    sha256 "0a64060a1342e7102d6d0e50104ac7a5192e8bf9a8816bd350c581a19efecabe"
+    sha256 "3a1416cb61322d327c34dd6858c5b61048a9142cf9038b5d008e1527fa74a3fc"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.19.rb
+++ b/Casks/terraform-0.12.19.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.19" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.19/terraform_0.12.19_darwin_amd64.zip"
-    sha256 "4d7be70cfbaaa17828a59cbe03db255d44cfc342658aa5c36a2153b84b9ec1c1"
+    sha256 "36a013a207a8fd0f23d07ee2cf8fb1ac0e547fccf94215e9d2b5d77862e7f758"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.20.rb
+++ b/Casks/terraform-0.12.20.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.20" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.20/terraform_0.12.20_darwin_amd64.zip"
-    sha256 "d814abcba5fded1ad71fca9b133c744d9b62d69dda02d206edcd9d72656d2ef2"
+    sha256 "67d143f187d0bc7293a40cbbf465b4fdd585669252c522a9b0b96544e0987c1d"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.21.rb
+++ b/Casks/terraform-0.12.21.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.21" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.21/terraform_0.12.21_darwin_amd64.zip"
-    sha256 "2c9dd0e08cf808f532710e97392f67bcccc3bc8f9fe6cc040237c62940ee6b48"
+    sha256 "2303c361e66ae64ccbf09b0e1c50cea4f28727e913c52d930e8a885d79c099f3"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.22.rb
+++ b/Casks/terraform-0.12.22.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.22" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.22/terraform_0.12.22_darwin_amd64.zip"
-    sha256 "efb9b86830b08e20723acaf4f2eadb3ff934fb9a89584afaaf20b9572a955de6"
+    sha256 "7e2c6d74fb3ff141976567b3903d3ffc6721230d3dd4e346e4c09de146a947bb"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.23.rb
+++ b/Casks/terraform-0.12.23.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.23" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.23/terraform_0.12.23_darwin_amd64.zip"
-    sha256 "dc0586ac38232e2b50251efcca3b9911cf263d285a8cf3c0b68538dbdb3b72f4"
+    sha256 "12293764366ade518e2022c6ad981712e029e24bdbf3e1d5822de82dec1a6dbd"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.24.rb
+++ b/Casks/terraform-0.12.24.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.24" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_darwin_amd64.zip"
-    sha256 "c67a5870977372cf0761de57403abd0bec4d82a18e2cbac1b4e0f25d4bc4c838"
+    sha256 "d97e5bb1064aa2da0b82865ecf588bea20afdd6bfaf0692fafcb9ff765de9b2b"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.25.rb
+++ b/Casks/terraform-0.12.25.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.25" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.25/terraform_0.12.25_darwin_amd64.zip"
-    sha256 "6c5160a6e1ede47be445d4c4f48e77da4a2f508e278738cb0ccc6c3104102783"
+    sha256 "d3592d13da863f65b57be78f9ab264b3a738cc0b972c7fa02996d5932237e44d"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.26.rb
+++ b/Casks/terraform-0.12.26.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.26" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.26/terraform_0.12.26_darwin_amd64.zip"
-    sha256 "d100f6949ba4de1f44ba02cac02550e416bfed93b31c0bcc082a3772ff22de1d"
+    sha256 "5dd8deea9060d2d90b748425cde9063620131f02922a993e3d925048375d9b29"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.27.rb
+++ b/Casks/terraform-0.12.27.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.27" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.27/terraform_0.12.27_darwin_amd64.zip"
-    sha256 "7bd1f1a45393d360db68d8338a40f56c1448c30c932353d5e26ffe5dbdefab50"
+    sha256 "06eaab0bc3451b4d2f7feb47f5587399702d19b9044f5705dc76ad77b401e26f"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.28.rb
+++ b/Casks/terraform-0.12.28.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.28" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.28/terraform_0.12.28_darwin_amd64.zip"
-    sha256 "fee2663bbe4d80149f6c1df166c780380e7c7500d87f100678eb66784adc0283"
+    sha256 "2c144bdd455d2cf059ff2e6db048667d6e093f29de172188aad176325ca5dc68"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.29.rb
+++ b/Casks/terraform-0.12.29.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.29" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_darwin_amd64.zip"
-    sha256 "756b5d0d3d22d3d9f4d70aa79612e8137230228f491c2dba885c37130815e7cf"
+    sha256 "a920c9fcf912b5f83a4e57cb8ab7afbe5615ec54edd893271c8d271a4d945592"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.30.rb
+++ b/Casks/terraform-0.12.30.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.30" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.30/terraform_0.12.30_darwin_amd64.zip"
-    sha256 "cf7df9be4c5261a7fbca0438380379c408cd49d12fbd1bbeb9faafb696790021"
+    sha256 "7d1a1d12bedce7b2c474495db0d777389a4e9b02181ad4db9bda3511e586f8e0"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.31.rb
+++ b/Casks/terraform-0.12.31.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.31" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_darwin_amd64.zip"
-    sha256 "794e736283b93b364d7f1c36ec8f47912ec6f6a0692b2108d0fb3908b5d3b5af"
+    sha256 "ebd96d0c1fc206480a61a190059d3e8aebdfa8733bfa309d7a34ad5a3e0eb322"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.7.rb
+++ b/Casks/terraform-0.12.7.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_darwin_amd64.zip"
-    sha256 "3d177358812c3d40259aed68adbc369c0ce17c5127763a9ac79b270378555467"
+    sha256 "17471e64e85e91c9309e9e17df7b8740664b2b58b6f1d6088dfc400a995b0413"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.8.rb
+++ b/Casks/terraform-0.12.8.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.8" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.8/terraform_0.12.8_darwin_amd64.zip"
-    sha256 "f4b80a1b04246c9b7cf2689a69f8f68f9b07e53b568c1329bcc8cd87dcd38e39"
+    sha256 "6f472c3cff1b679c43ebf128e164d35fc15ff95f10a8a02f9027fd60a0bcab6f"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.12.9.rb
+++ b/Casks/terraform-0.12.9.rb
@@ -7,7 +7,7 @@ cask "terraform-0.12.9" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_darwin_amd64.zip"
-    sha256 "5751e34b5d1641c9661420ea69b4e60d96f5cafdb5a7bcfe7804f036c5f0c0c6"
+    sha256 "d8314eda99d48f17c737643eb1804c654c6e08c53465dd0fa8d8348c77150e6b"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.0-beta1.rb
+++ b/Casks/terraform-0.13.0-beta1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.0-beta1/terraform_0.13.0-beta1_darwin_amd64.zip"
-    sha256 "9c24cd6e18482b7b5ddc60e00ea08b52e0b1f18b01d8b3196f1dadeea59647bd"
+    sha256 "e04f099544df4725b16e4c8835c08f880cf960441bebd9baea868ea4d39f6f6f"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.0-beta2.rb
+++ b/Casks/terraform-0.13.0-beta2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.0-beta2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.0-beta2/terraform_0.13.0-beta2_darwin_amd64.zip"
-    sha256 "ffe52a79916102639a3b2646be237fe7b2748436c8c198099cc87c0a615ac9c2"
+    sha256 "44c3afe6bb53020a82341c26ac36612a32a135163ff490aa778e9eefa53bf0f3"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.0-beta3.rb
+++ b/Casks/terraform-0.13.0-beta3.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.0-beta3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.0-beta3/terraform_0.13.0-beta3_darwin_amd64.zip"
-    sha256 "dc867d549b1c7140d22e6a5f41fbcaa4d4db9190d191ed1b8c3ab9e1a1afa655"
+    sha256 "a4916de8ba4fd28699d4cdab540f9f58cc8941966d276c4ba12f4afdeffd029d"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.0-rc1.rb
+++ b/Casks/terraform-0.13.0-rc1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.0-rc1/terraform_0.13.0-rc1_darwin_amd64.zip"
-    sha256 "6920d32c38c8942e853b29041932cdf1174dca177fc9f0bf7b2f0e9869b139b5"
+    sha256 "2bbbe855e1e09f03ff06334a7f0b3ba15506e6ac4deb25938f34bb210540a687"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.0.rb
+++ b/Casks/terraform-0.13.0.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.0/terraform_0.13.0_darwin_amd64.zip"
-    sha256 "d21665e66ded549916804449fb93bb743ddd60847b31f429c241cbbcb5a0f563"
+    sha256 "1ffcd96037faffad5c8692fd989d5f261fdddc8b0fede3996aa09b7bfe6b1b01"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.1.rb
+++ b/Casks/terraform-0.13.1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.1_darwin_amd64.zip"
-    sha256 "1c6466be64700f1ae718432789ff2d553076da1de63e08e818de0e478e9eb4e2"
+    sha256 "8c9bab51223e7039572763326267c1989d1727f552b3728f586cfa868b01b537"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.2.rb
+++ b/Casks/terraform-0.13.2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_darwin_amd64.zip"
-    sha256 "e6acad92937713255227030559d49b1df18d75abf2add087906f4f47ec6fa585"
+    sha256 "8f2ef6fe5727014dde0496d88dffab5fcafd0c35138466d19de2dd6147d96b90"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.3.rb
+++ b/Casks/terraform-0.13.3.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_darwin_amd64.zip"
-    sha256 "f74d0443acfb707c90241faf20071a973877ba24c1a12d57ba553be096fa628c"
+    sha256 "4a613dc18ff8cfac525a59cc0e78216fa0a9ecd63e6ac45603561ceb72f6d772"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.4.rb
+++ b/Casks/terraform-0.13.4.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.4/terraform_0.13.4_darwin_amd64.zip"
-    sha256 "074f88409e7b1aab095231841e5920255690520d499d8c41c397e49f16c3de15"
+    sha256 "5011d509a23ed6e2010a25f0449552b03822d7ef9b8b48f8a2f3277f2f34b736"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.5.rb
+++ b/Casks/terraform-0.13.5.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_darwin_amd64.zip"
-    sha256 "7c196875d9d9f03c6218581622bb5e66f15a98de764a8daf09eb40183d2145ce"
+    sha256 "6ede2ffced90d7ad0050ac5ff4c617ef7f07d1d2522b6ba83a07e5e980c28775"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.6.rb
+++ b/Casks/terraform-0.13.6.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.6" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.6/terraform_0.13.6_darwin_amd64.zip"
-    sha256 "1df49e6f05804a08a7f9d3ea6c393d20ae43e2a74722cd64f3e120d49e0b57d4"
+    sha256 "dd933ecd25f38c23e2f7e70503912362429ce251d4d5ef17f4be55bbfd55bafd"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.13.7.rb
+++ b/Casks/terraform-0.13.7.rb
@@ -7,7 +7,7 @@ cask "terraform-0.13.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_darwin_amd64.zip"
-    sha256 "2ee62413afc847d9771d46d73fad6c7e8670bcdf44190320b5fb6a3a38ec6480"
+    sha256 "60f3561eb11fa6c61321d6c8b698023eb7b74dc1a49210bd5f5acb03f453db9b"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0-alpha20200910.rb
+++ b/Casks/terraform-0.14.0-alpha20200910.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0-alpha20200910" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0-alpha20200910/terraform_0.14.0-alpha20200910_darwin_amd64.zip"
-    sha256 "2068bbedc098668b7a84ba08069ddb4a4622d782ee4f3b0eaf5dd034273da0b0"
+    sha256 "e75122707182459bd997aafe6b5559260d3429ab09b11547de78b053f4b674ce"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0-alpha20200923.rb
+++ b/Casks/terraform-0.14.0-alpha20200923.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0-alpha20200923" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0-alpha20200923/terraform_0.14.0-alpha20200923_darwin_amd64.zip"
-    sha256 "03fbdbca7f40731b58b0925dc55010a1d99c294b4cc9d6c4faa2472fc63284de"
+    sha256 "adc3dd2d8f4e53d66b09dd9ee9b57e48a60aab34e7bfc013867ed278648594ac"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0-alpha20201007.rb
+++ b/Casks/terraform-0.14.0-alpha20201007.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0-alpha20201007" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0-alpha20201007/terraform_0.14.0-alpha20201007_darwin_amd64.zip"
-    sha256 "a334ee3d6195e3aa39127bbff36c7ec614f8758d85d70259341a1e9934595a59"
+    sha256 "542f89fd3005dfe9e7d2583182f78872def6a82dda31acafde3f0f8fa99f5098"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0-beta1.rb
+++ b/Casks/terraform-0.14.0-beta1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0-beta1/terraform_0.14.0-beta1_darwin_amd64.zip"
-    sha256 "691ec8a5be44b78e306123c033961d841506b6af54c511cef22bfb7385008361"
+    sha256 "8ecff69cebdd6f5bb7448bff82813eb978c1c3714976e38ca7ef8115f259f3f7"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0-beta2.rb
+++ b/Casks/terraform-0.14.0-beta2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0-beta2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0-beta2/terraform_0.14.0-beta2_darwin_amd64.zip"
-    sha256 "377213a1387367358b1f81cb46faaa1c3ccdeedab1d4afea39efd6997d534391"
+    sha256 "b6bbb9b918dad1dabfcc8be5d0c143ef03d27f981b1af17470b45c04604a93cb"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0-rc1.rb
+++ b/Casks/terraform-0.14.0-rc1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0-rc1/terraform_0.14.0-rc1_darwin_amd64.zip"
-    sha256 "578803405810e49a23ddb694299062561b456f69d7a3a0162aab13fdba3aef17"
+    sha256 "4fff2d849d96c6278188dfe10d371863253b8f789c98d17c8cffc4eda738810e"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.0.rb
+++ b/Casks/terraform-0.14.0.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.0/terraform_0.14.0_darwin_amd64.zip"
-    sha256 "b0c216023e42e69c09b953653c22f0421a2d24a62c124cd89adf468165de70ea"
+    sha256 "6bbf84885f15688c427726306331a2599af3041bb86d9330819d435db516e15c"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.1.rb
+++ b/Casks/terraform-0.14.1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.1/terraform_0.14.1_darwin_amd64.zip"
-    sha256 "06704f482319c703aa155ae9c2d3c8cd42ad2d8fcce3de8644dc29354bb52d80"
+    sha256 "3211e5858a7cf2f81f46a3ff2fa577c70998e0af22b589eb4cfa8057fa27f576"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.10.rb
+++ b/Casks/terraform-0.14.10.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.10" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.10/terraform_0.14.10_darwin_amd64.zip"
-    sha256 "26890407b6580adef5fdfdf87f9cca3047d061230191af55d49774522e8f8eb5"
+    sha256 "ac56b87611ea4cff4b1f21d320d38a46dac0e4730d1d90509f46b0bcb2f5c50e"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.11.rb
+++ b/Casks/terraform-0.14.11.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.11" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_darwin_amd64.zip"
-    sha256 "143ee31a4ae61564762ca5fe40851a0ec661698b73026e3cc0061f9867c7b67f"
+    sha256 "88d266a53b4c09e9778123f274351d7f6e48c08c12edaece8f4e360ade3bd847"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.2.rb
+++ b/Casks/terraform-0.14.2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.2/terraform_0.14.2_darwin_amd64.zip"
-    sha256 "02b71faa013ae13ddfe82181a0d8a5774ac915811aab01064edcb0104993b101"
+    sha256 "f26da93e17f347b345555e74d33f3aa79c60ac77efc995e1eb6018ffa06cb70c"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.3.rb
+++ b/Casks/terraform-0.14.3.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.3/terraform_0.14.3_darwin_amd64.zip"
-    sha256 "68ba55ae728d8f568ea464adf897e265bc51c38452880a08632b7b76f11dd7dd"
+    sha256 "577f5bdb4dc0828737389b634b07895e971c7860b1e01bc765fdd9563c5ce1a4"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.4.rb
+++ b/Casks/terraform-0.14.4.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.4/terraform_0.14.4_darwin_amd64.zip"
-    sha256 "b69403f2893ddcd3cb7bd9d6d45627862f9eb88c1a1e2dd6e26560055a45b50b"
+    sha256 "9efab671f69dd277ab961aff36c17bc2c33a927246b51c55df3816bfd3184966"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.5.rb
+++ b/Casks/terraform-0.14.5.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_darwin_amd64.zip"
-    sha256 "4b8633c12e999b0b8cc40cfb3b8b9b9a82d68b05334a188a7f842cbfa4efb495"
+    sha256 "2edf2491d3b6a98949bb83b427713fdae14780ca9eeb2d6504e4a4325ba5383a"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.6.rb
+++ b/Casks/terraform-0.14.6.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.6" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.6/terraform_0.14.6_darwin_amd64.zip"
-    sha256 "8a8086cab3a7fd812dd5e6ba9801bea1eaab154d5b53e4a9d50850231c1bd7a3"
+    sha256 "d83b0427138749ae105ae10fa65cbb81027b5efc970bacd3911c674af932e27c"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.7.rb
+++ b/Casks/terraform-0.14.7.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_darwin_amd64.zip"
-    sha256 "35dbd2e1bd3efdfabbba8c907bd08c4e762e8b15bbc33cb6a38467bfc2c27539"
+    sha256 "bd4afbb92cfc99f3f7e81412536e1aa9bafd6544a87454286d9e9f6ab446179a"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.8.rb
+++ b/Casks/terraform-0.14.8.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.8" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.8/terraform_0.14.8_darwin_amd64.zip"
-    sha256 "8920b658fd03722d44acaae4a633d72cffe425cab4cbbea7b0c28d5ea7f72127"
+    sha256 "596363941c5acfb05d81f6fe8813f007427de0e976972bdd60106bf4e6d8eb54"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.14.9.rb
+++ b/Casks/terraform-0.14.9.rb
@@ -7,7 +7,7 @@ cask "terraform-0.14.9" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.14.9/terraform_0.14.9_darwin_amd64.zip"
-    sha256 "606357dfdb39d5b6ae39c2b81c9468ae9cd42f02dadfc9174232cd1b974adf9b"
+    sha256 "a62e812d068b44b8a93d8b2fc024850ad69cb5ce7f9b0bfc68e836b90a06693d"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-alpha20210107.rb
+++ b/Casks/terraform-0.15.0-alpha20210107.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-alpha20210107" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-alpha20210107/terraform_0.15.0-alpha20210107_darwin_amd64.zip"
-    sha256 "aa26215c955041732313a82a1f65174e5ddc20f27c857b46a90867602ea48423"
+    sha256 "b5a95586cead146ef532642079dd3e4bb93f0ab785b5bc57c5c6259eb0da2d37"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-alpha20210127.rb
+++ b/Casks/terraform-0.15.0-alpha20210127.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-alpha20210127" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-alpha20210127/terraform_0.15.0-alpha20210127_darwin_amd64.zip"
-    sha256 "02b3d4dcbd9959f31b7cfac5b1abf3bcf6298d73c2fc07e7df1a611cc5c71f55"
+    sha256 "ee7cf15916da97bd0959b2928bd1c23afd9d4e6a06a9529ee398d79dd490a452"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-alpha20210210.rb
+++ b/Casks/terraform-0.15.0-alpha20210210.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-alpha20210210" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-alpha20210210/terraform_0.15.0-alpha20210210_darwin_amd64.zip"
-    sha256 "5bb761dc863faa4471b33bb2fb293e27a8af7eb201c35bb10d2ce7e8ddfb20bd"
+    sha256 "3fcccd708947e8d8ac54a6a5b9b4835c410336506aa3ce25579c40c2df854423"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-beta1.rb
+++ b/Casks/terraform-0.15.0-beta1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-beta1/terraform_0.15.0-beta1_darwin_amd64.zip"
-    sha256 "fac5a5e595344b68ccc3c06208cc310e3da0602c2f1cdb794bfa074d4d2dbe93"
+    sha256 "bf4484361e9b2348b2f61856855c90f010c3cba927851dfcea3a3ac027306519"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-beta2.rb
+++ b/Casks/terraform-0.15.0-beta2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-beta2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-beta2/terraform_0.15.0-beta2_darwin_amd64.zip"
-    sha256 "c974ca266dd8efbfda4303c96e2add991a7a96f32665b580cfc727099aa36e21"
+    sha256 "b669d9b4322f70f292761f62c43751d1a2ce583381336428c3adda3094874dbc"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-rc1.rb
+++ b/Casks/terraform-0.15.0-rc1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-rc1/terraform_0.15.0-rc1_darwin_amd64.zip"
-    sha256 "8fe6b38c033a32082679282e64186a5000d1c91031ad26d4b99250ee0c33c693"
+    sha256 "57bd815c2e0ba101ab7bce3d00585430ec2e74d289dfbbe47e336551c48f914f"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0-rc2.rb
+++ b/Casks/terraform-0.15.0-rc2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0-rc2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0-rc2/terraform_0.15.0-rc2_darwin_amd64.zip"
-    sha256 "04a54c3dd8723cfe824ac6605bf013c147872a228736564b79eb20799e1800a9"
+    sha256 "73347bb7965b6681b7dc10f45d0eeec28b5916cbadb62ff97e9a885956ab9201"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.0.rb
+++ b/Casks/terraform-0.15.0.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.0/terraform_0.15.0_darwin_amd64.zip"
-    sha256 "394137bff715926be15b27abc867409b81a67c10efe8179a3298bb5cff4d8e61"
+    sha256 "de9c15e25b5f60fd6cb4bdabf16cff252977a97afde6cfda8d465ef28be5fd81"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.1.rb
+++ b/Casks/terraform-0.15.1.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.1/terraform_0.15.1_darwin_amd64.zip"
-    sha256 "754543a004e9545ecbfb8a319a19cd734faea98c06b2345347077d9d1a0c21d9"
+    sha256 "7f457dd1268ad616b9f832c4b731456676a860a3ecf4b2751957a0e7cf38924d"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.2.rb
+++ b/Casks/terraform-0.15.2.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.2/terraform_0.15.2_darwin_amd64.zip"
-    sha256 "ff5a2f187a2c0ba214ee0a4ab766a1c9025e5b4335b14da89c15cfe8b3bed2ca"
+    sha256 "74b7317085f86b34c7dc1a1a97d8f3f1b418a56d1b3bf51c869c432851fa1138"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.3.rb
+++ b/Casks/terraform-0.15.3.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.3/terraform_0.15.3_darwin_amd64.zip"
-    sha256 "7ef568de653461b2b11b94498b79d737d0812e02093a1ef16061c489df63bc0f"
+    sha256 "2521b478aef5b8c9f374d0caa265bee2a03f31f290ee8d048eb2f110eb4ffc8e"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.4.rb
+++ b/Casks/terraform-0.15.4.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.4/terraform_0.15.4_darwin_amd64.zip"
-    sha256 "fe44710382dddb06b9fa113ed04018d022dae60ed44d9906a703b81cdfa6993a"
+    sha256 "9092c017257ead94223418dac7165541228e773463b476e0803848be4f3169a4"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-0.15.5.rb
+++ b/Casks/terraform-0.15.5.rb
@@ -7,7 +7,7 @@ cask "terraform-0.15.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_darwin_amd64.zip"
-    sha256 "4ee2ed9b769426cc9f13bd26c133ee66c6046acffeef632ddf0ef66e3d36a981"
+    sha256 "5ad75ed3def05f36b5c5dab97dee00b5d3d86be9f9dcd205b48136312505f3fc"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-1.0.0.rb
+++ b/Casks/terraform-1.0.0.rb
@@ -7,7 +7,7 @@ cask "terraform-1.0.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.0/terraform_1.0.0_darwin_amd64.zip"
-    sha256 "2051ba2647b343ebac70108d059d85b6c66f3213d23091ce36f898abf019833f"
+    sha256 "397eccdf68eb343e4946c37a877a4764409fe0b9037041daf1d17db18bca9839"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-1.0.1.rb
+++ b/Casks/terraform-1.0.1.rb
@@ -7,7 +7,7 @@ cask "terraform-1.0.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.1/terraform_1.0.1_darwin_amd64.zip"
-    sha256 "06e796fb25c0ef089f48efbf7384cd1844c094222a4d3aeed6f4470932af9b6c"
+    sha256 "260524ebe620a73df4c9732fec6887e74414df6d3210f5c6eaca24558f320938"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-1.0.10.rb
+++ b/Casks/terraform-1.0.10.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.10" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.10/terraform_1.0.10_darwin_amd64.zip"
-    sha256 "a935053f20f4f38bee225fe91547457f1bc0de1aef6ac225a2460e15b72b0c83"
+    sha256 "077479e98701bc9be88db21abeec684286fd85a3463ce437d7739d2a4e372f18"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.10/terraform_1.0.10_darwin_arm64.zip"
-    sha256 "430c08fe7c5b6d965fb60690cebd79ddab94f4c6b9fab851af3a827dbc8a5e59"
+    sha256 "776f2e144039ece66ae326ebda0884254848a2e11f0590757d02e3a74f058c81"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.11.rb
+++ b/Casks/terraform-1.0.11.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.11" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_darwin_amd64.zip"
-    sha256 "5b6771c87f3febde756baa132d38a67fcac284291a1f88918a58a41d879d2558"
+    sha256 "551a16b612edaae1037925d0e2dba30d16504ff4bd66606955172c2ed8d76131"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_darwin_arm64.zip"
-    sha256 "435cc512332c28c38c98cda11a2ef3670564cfc85ba4e6fe0a73462713799f9e"
+    sha256 "737e1765afbadb3d76e1929d4b4af8da55010839aa08e9e730d46791eb8ea5a6"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.2.rb
+++ b/Casks/terraform-1.0.2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.2/terraform_1.0.2_darwin_amd64.zip"
-    sha256 "1c173ba93d8d6f00b3bd8908c0a1de6fd3a04c2ba4d6ff5f3361e0b56d139154"
+    sha256 "f323afd5804bf6dbe639585bea5edc68f429011fc8a44519f3f1654ab88e9a5f"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.2/terraform_1.0.2_darwin_arm64.zip"
-    sha256 "a5d03ea237f838d87396a8a53f42bc490687c8aa1283b830a0604e1e1bd54d31"
+    sha256 "f653da49e48dfd677403ba6babede93918ab4196280c0ea4d64a442d948723b6"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.3.rb
+++ b/Casks/terraform-1.0.3.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.3/terraform_1.0.3_darwin_amd64.zip"
-    sha256 "2a8be22018464e981461f0ad1296946d97d6d85b366565eea46c545ded86bc24"
+    sha256 "6e86dfff2f90ddc1232b38487613d5f7eab69f227d76c4337921517aaaa11c4f"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.3/terraform_1.0.3_darwin_arm64.zip"
-    sha256 "134bb5581b091c8efe45f61eebd301aca9ff7b0c7491a254287cd0411dfe7a93"
+    sha256 "a16f8851e11fcc5b922c529169918b05d39ffd85557e6bbbcd7843cf07e47910"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.4.rb
+++ b/Casks/terraform-1.0.4.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.4/terraform_1.0.4_darwin_amd64.zip"
-    sha256 "a4c40903d351f621f9640316f91efb6294cd53be1f8bec9314c8298f5248af01"
+    sha256 "0d2083b1a812572eef068dbfd60ffbfa10f843434bec5f7e82c5f7a778761fa1"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.4/terraform_1.0.4_darwin_arm64.zip"
-    sha256 "fcf5959566d5fd48acd7846d497be1cead90adf333fdf951649730127281815d"
+    sha256 "8942347acdf0e5499366c6ee4fc1da7a4b4c24f9d80113a12e8b72619786b7eb"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.5.rb
+++ b/Casks/terraform-1.0.5.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.5/terraform_1.0.5_darwin_amd64.zip"
-    sha256 "c62492495b455e6877359c01710c6c063c00c21b0abbd593ce3a2b6aa2605daa"
+    sha256 "51b481f2cc02651c14854f57dc0c43c3918b19b6fc5e687295b98beee5d20271"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.5/terraform_1.0.5_darwin_arm64.zip"
-    sha256 "19b842a67a0f85b79c67cce604091ef2c87946c6d469d7c654751dc084c484d0"
+    sha256 "8fadd8bbcdcaf6452d9937af6b916572f481caabcc29ea9aac61c7f4759e133e"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.6.rb
+++ b/Casks/terraform-1.0.6.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.6" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.6/terraform_1.0.6_darwin_amd64.zip"
-    sha256 "a6066c152a8a48f8d23ca63a3b095680247f7003ad5145b905c3791db76fbc44"
+    sha256 "5ac4f41d5e28f31817927f2c5766c5d9b98b68d7b342e25b22d053f9ecd5a9f1"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.6/terraform_1.0.6_darwin_arm64.zip"
-    sha256 "6c54f8efe20d801066e7a3c0cd0d0b828e7e6bf6e3b820fd9435b4e8711f52aa"
+    sha256 "613020f90a6a5d0b98ebeb4e7cdc4b392aa06ce738fbb700159a465cd27dcbfa"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.7.rb
+++ b/Casks/terraform-1.0.7.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.7/terraform_1.0.7_darwin_amd64.zip"
-    sha256 "909ca6950538a8a93c8d99c990b99b4a63285aadc57a7ec7d3b60aa0859fdc2c"
+    sha256 "23b85d914465882b027d3819cc05cd114a1aaf39b550de742e81a99daa998183"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.7/terraform_1.0.7_darwin_arm64.zip"
-    sha256 "014b781faf36bfe55ccb6c98e51b46ab6ef006890249a122bdeca0b208bf5396"
+    sha256 "d9062959f28ba0f934bfe2b6e0b021e0c01a48fa065102554ca103b8274e8e0c"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.8.rb
+++ b/Casks/terraform-1.0.8.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.8" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.8/terraform_1.0.8_darwin_amd64.zip"
-    sha256 "1f36f77b59354ac398b8da33f903b1fa6d367dc7794a00f3b19729547bb8eca7"
+    sha256 "909781ee76250cf7445f3b7d2b82c701688725fa1db3fb5543dfeed8c47b59de"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.8/terraform_1.0.8_darwin_arm64.zip"
-    sha256 "83dbd3b7119dbdc631e52664d8fcff2ae891fee851757ab3dc4df395c0eecf2d"
+    sha256 "92fa31b93d736fab6f3d105beb502a9da908445ed942a3d46952eae88907c53e"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.0.9.rb
+++ b/Casks/terraform-1.0.9.rb
@@ -7,10 +7,10 @@ cask "terraform-1.0.9" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.0.9/terraform_1.0.9_darwin_amd64.zip"
-    sha256 "09d11c9867fce95f567c2ee285ad6883206b75220f39eef834c8592e7a5a2c39"
+    sha256 "be122ff7fb925643c5ebf4e5704b18426e18d3ca49ab59ae33d208c908cb6d5a"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.0.9/terraform_1.0.9_darwin_arm64.zip"
-    sha256 "f963b2e1ae5338a24e6f53e85f46b66e44e9227665cd56bafe659be2a517c39d"
+    sha256 "89b2b4fd1a0c57fabc08ad3180ad148b1f7c1c0492ed865408f75f12e11a083b"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20210616.rb
+++ b/Casks/terraform-1.1.0-alpha20210616.rb
@@ -7,7 +7,7 @@ cask "terraform-1.1.0-alpha20210616" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210616/terraform_1.1.0-alpha20210616_darwin_amd64.zip"
-    sha256 "e7f82bb8769501e8794ec3b82f75243827605a64b456893427529215492ba622"
+    sha256 "fd9a9c6ae65f3678b81e4ba5fe72350f0191ed0a0fc2ec12a6139e3a8887e203"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-1.1.0-alpha20210630.rb
+++ b/Casks/terraform-1.1.0-alpha20210630.rb
@@ -7,7 +7,7 @@ cask "terraform-1.1.0-alpha20210630" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210630/terraform_1.1.0-alpha20210630_darwin_amd64.zip"
-    sha256 "efe9cd45371847e46f3e416e28b8f0903b94736e757b3ece487c2cfa093355ec"
+    sha256 "bd8d4a966661875b5c38e7d77a5aabcabb1bd98630c014a4626cbc4b2f8b8f9e"
   end
 
   depends_on arch: [:x86_64]

--- a/Casks/terraform-1.1.0-alpha20210714.rb
+++ b/Casks/terraform-1.1.0-alpha20210714.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20210714" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210714/terraform_1.1.0-alpha20210714_darwin_amd64.zip"
-    sha256 "91e25a3f563a34a69ba7345631ef5490d78abc6d087cb08a8544e12102abe802"
+    sha256 "a848f98f2eaa2ef6816d558bf63badccfa16872520ad663ccdc37477dcdefb2c"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210714/terraform_1.1.0-alpha20210714_darwin_arm64.zip"
-    sha256 "2b22c319b7b1265e5ff1d27840395cbb020831110ddfbc2c03372f2fcc7d9317"
+    sha256 "1eda0c53c37ae48714168552a1ed90636b7838da38d39e33a27ca87fa23cda33"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20210728.rb
+++ b/Casks/terraform-1.1.0-alpha20210728.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20210728" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210728/terraform_1.1.0-alpha20210728_darwin_amd64.zip"
-    sha256 "bbdfd6588598b96273f1c79f3c67ceafdbf0095f58bfe8abf5cfeae5650387a8"
+    sha256 "9b63d9bab48bc9dfc3cb719fb8869746f7d16626888c2895c18e000fcf80cacd"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210728/terraform_1.1.0-alpha20210728_darwin_arm64.zip"
-    sha256 "261123d44899baaa8147a97978651b41d7f3b5d8f43f470ee01e0e16bb4b38a9"
+    sha256 "b0c793e019ba8e43c9d0d9287463b5ddd8c09afcb06863f0270334c7ae3e74b2"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20210811.rb
+++ b/Casks/terraform-1.1.0-alpha20210811.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20210811" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210811/terraform_1.1.0-alpha20210811_darwin_amd64.zip"
-    sha256 "5382962ea627602a94018289ae3485eea66ee659b148854c39c6b3254e5b8c41"
+    sha256 "bd9afe8033bda2b04e18d97d5bd0f77a9cd80747e9ff8aff4ab83263fd81d76c"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210811/terraform_1.1.0-alpha20210811_darwin_arm64.zip"
-    sha256 "cc415c7810cd7f0f3865261afbdc162b77ef330bd8e9c6df27ac9a4cd1405b5a"
+    sha256 "22628eca35df6019891929f49466f2512bc0032c10014076c2b2e5637be6f8e4"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20210908.rb
+++ b/Casks/terraform-1.1.0-alpha20210908.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20210908" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210908/terraform_1.1.0-alpha20210908_darwin_amd64.zip"
-    sha256 "367b1f8da46936b9155d3351acc5e1bab4189d38cfe24f24182ec2c0350e8e4d"
+    sha256 "e23c5f21b4d9cda9f2965a4cc38109e26e0decb77b11e378c4e526a35ab66ff6"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210908/terraform_1.1.0-alpha20210908_darwin_arm64.zip"
-    sha256 "d9bbca900f4a09708766a31088947f47a0645d64f983b3fd039d2c2e920289c5"
+    sha256 "5830f3197ccd3485fc59d808bfc90e852b4f1246e1b39dd0c5250e118943ecc5"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20210922.rb
+++ b/Casks/terraform-1.1.0-alpha20210922.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20210922" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210922/terraform_1.1.0-alpha20210922_darwin_amd64.zip"
-    sha256 "11a1cfc4d9618cb6d06ad1468c4409df1673c1fb1a35e07d557c43d86f856dd6"
+    sha256 "79fb74af2ca42e39f217db4ca8cadd4a47ae900f632ec947b24738c65b80e40a"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20210922/terraform_1.1.0-alpha20210922_darwin_arm64.zip"
-    sha256 "fd9e3b693e61fe7bc796735ad2792fbff600e615c972446a0cda871a356190d8"
+    sha256 "d84fd0d2e967d2a822cf86c937739672ae533169af4b36cd8c6880f81847406b"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20211006.rb
+++ b/Casks/terraform-1.1.0-alpha20211006.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20211006" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20211006/terraform_1.1.0-alpha20211006_darwin_amd64.zip"
-    sha256 "71de072c22f3a546e76c5ab93bc4a8ec0190eb201dde14a7c73fe77f229644e1"
+    sha256 "11eddb6bd353f801e0e0b38d29859e31897eac404285d60424611d6fa2ddda33"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20211006/terraform_1.1.0-alpha20211006_darwin_arm64.zip"
-    sha256 "6aae75e171b6a06172ecc1c077a207a552951ff10f593954472cb5791a3d15d7"
+    sha256 "fff8eceebfef30eeb52ca153033f69d7dd0925951deb42b016ad84c04aa7f643"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20211020.rb
+++ b/Casks/terraform-1.1.0-alpha20211020.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20211020" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20211020/terraform_1.1.0-alpha20211020_darwin_amd64.zip"
-    sha256 "c86d0aa04c3dc85a7e41e006195041424527ff61b7ec75ff8df78a1d531661e3"
+    sha256 "c7141fa2ad25a856155284c79b295e2054f417a3bfca88508419dba058294e10"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20211020/terraform_1.1.0-alpha20211020_darwin_arm64.zip"
-    sha256 "30099d8ff71d4582e7ce96cef7cd5c9ccf3ac5090f66e1dc6cb44742de0aa48e"
+    sha256 "0302cb342a1f32d821929f130637af1b44dfd1732323c8bbed8a007d90a3396c"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-alpha20211029.rb
+++ b/Casks/terraform-1.1.0-alpha20211029.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-alpha20211029" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20211029/terraform_1.1.0-alpha20211029_darwin_amd64.zip"
-    sha256 "7b78c9f29ebac6e17af979654a1bf84901a7759c4f30c7ded88313d08abe98c7"
+    sha256 "de70d87ea634290ac03ee20c5901eb5cef68d42d1c5f74a001863f7479805646"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-alpha20211029/terraform_1.1.0-alpha20211029_darwin_arm64.zip"
-    sha256 "16ed907ee22a180a74558794cae3d46b39a66523fea69d159fabbb0e4c088e89"
+    sha256 "3631eec8ec544e56092f29e0e8c0466f86a94e92d5708823bcf36a189eaa0b74"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-beta1.rb
+++ b/Casks/terraform-1.1.0-beta1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-beta1/terraform_1.1.0-beta1_darwin_amd64.zip"
-    sha256 "42ae96bc9a9035b4a579ea2ba540a3d98e0e2c9f09427cebeb261d7cfe3423e7"
+    sha256 "9eecd065f592541b0aa444830e905606e549c92969526ff6a6b5d3d9059268a4"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-beta1/terraform_1.1.0-beta1_darwin_arm64.zip"
-    sha256 "1fd3b6943291dcd65d994e1f5ece54483cc21a7c021bebc6a58e1d02947b2dd7"
+    sha256 "c55dbc74a318761f13b8343a116b75a1720aa8153e409aca0ce4519debfafd55"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-beta2.rb
+++ b/Casks/terraform-1.1.0-beta2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-beta2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-beta2/terraform_1.1.0-beta2_darwin_amd64.zip"
-    sha256 "1c49422be110b5518c612968aa6b20e83a8fb74a88dd6b8fee2774b93e6cec9c"
+    sha256 "ccdcab84417c3643ab1f97fb97b6220ca9a27b8341746799130d8d4c55e65c6f"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-beta2/terraform_1.1.0-beta2_darwin_arm64.zip"
-    sha256 "03b5e40d214c885629c917571982350cf8a084a416d924d89b6c035b1dff3e00"
+    sha256 "8b9f02ba2e197ee439caa7150de13d293ce7b13156ad3ae296d1267b0ea422d7"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0-rc1.rb
+++ b/Casks/terraform-1.1.0-rc1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0-rc1/terraform_1.1.0-rc1_darwin_amd64.zip"
-    sha256 "cd140f8bc90aeb9c349d06655c4bd7fa6bb761a0fac774eaf81412dd4b4d6015"
+    sha256 "a6d28534ff87971f236173a231065ccbbd3565b7fe2ca4f750873c51db8a4fb0"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0-rc1/terraform_1.1.0-rc1_darwin_arm64.zip"
-    sha256 "1482dd6a92332bed861a8751da35b79e5e1ba28e399720cec668920b5bf0b280"
+    sha256 "3b005902d98f38aab052b233f15dab0048efba6b3a635ee255ce801df5e8aa97"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.0.rb
+++ b/Casks/terraform-1.1.0.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.0/terraform_1.1.0_darwin_amd64.zip"
-    sha256 "37ea10c6c24152e1e23ab1163a42cba93f3facd8a4b65a569d72373578f2151f"
+    sha256 "6e0ba9afb8795a544e70dc0459f0095fea7df15e38f5d88a7dd3f620d50f8bfe"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.0/terraform_1.1.0_darwin_arm64.zip"
-    sha256 "d1b17c019e6b0cfc4d286c6cd42b051278be91064d117bea3708a9396e39642e"
+    sha256 "7955e173c7eadb87123fc0633c3ee67d5ba3b7d6c7f485fe803efed9f99dce54"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.1.rb
+++ b/Casks/terraform-1.1.1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.1/terraform_1.1.1_darwin_amd64.zip"
-    sha256 "2850e6deb502bb34deb3e7ba0b45d302c017fff509d0e2ec39f99c1172f2bd37"
+    sha256 "d125dd2e92b9245f2202199b52f234035f36bdcbcd9a06f08e647e14a9d9067a"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.1/terraform_1.1.1_darwin_arm64.zip"
-    sha256 "fcaf92a9a9e6106d19b1bed54671809639946688ce02ad35b878802d01031bc2"
+    sha256 "4cb6e5eb4f6036924caf934c509a1dfd61cd2c651bb3ee8fbfe2e2914dd9ed17"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.2.rb
+++ b/Casks/terraform-1.1.2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.2/terraform_1.1.2_darwin_amd64.zip"
-    sha256 "18c8b539c4e319c151d94a9e068be3cd33323d42e1dc8065c7acbca9843fa2d5"
+    sha256 "78faa76db5dc0ecfe4bf7c6368dbf5cca019a806f9d203580a24a4e0f8cd8353"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.2/terraform_1.1.2_darwin_arm64.zip"
-    sha256 "782854af8366e15ab2140238133e85f0b0faf435e35ec352aabdf2dd6d09a744"
+    sha256 "cc3bd03b72db6247c9105edfeb9c8f674cf603e08259075143ffad66f5c25a07"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.3.rb
+++ b/Casks/terraform-1.1.3.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.3/terraform_1.1.3_darwin_amd64.zip"
-    sha256 "6c6e5503b8a94286a6a883e3ff98777a9e372783bd1929db1377f70e9ce262c2"
+    sha256 "016bab760c96d4e64d2140a5f25c614ccc13c3fe9b3889e70c564bd02099259f"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.3/terraform_1.1.3_darwin_arm64.zip"
-    sha256 "ebb664e8840e029f9112c7ce58cb4857a99585cdfef8cdda6490e8851ca88bc5"
+    sha256 "02ba769bb0a8d4bc50ff60989b0f201ce54fd2afac2fb3544a0791aca5d3f6d5"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.4.rb
+++ b/Casks/terraform-1.1.4.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.4/terraform_1.1.4_darwin_amd64.zip"
-    sha256 "ec38bbc7a0153fe15cecc29895cbf0c4fb22228e8408538af99af59414f14b6c"
+    sha256 "4f3bc78fedd4aa17f67acc0db4eafdb6d70ba72392aaba65fe72855520f11f3d"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.4/terraform_1.1.4_darwin_arm64.zip"
-    sha256 "d13e93873f3831eb221391e5ad4d1da37becea5476a88663141325378613829c"
+    sha256 "5642b46e9c7fb692f05eba998cd4065fb2e48aa8b0aac9d2a116472fbabe34a1"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.5.rb
+++ b/Casks/terraform-1.1.5.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.5/terraform_1.1.5_darwin_amd64.zip"
-    sha256 "7b07795ac98ed7efb7aae509013cd99c83a4f9154c8a11adb57b7786716038f1"
+    sha256 "dcf7133ebf61d195e432ddcb70e604bf45056163d960e991881efbecdbd7892b"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.5/terraform_1.1.5_darwin_arm64.zip"
-    sha256 "4e5e2746a984a9ba80f9277fd80a08db852b9303b0fabaa3288247a16e7b2e37"
+    sha256 "6e5a8d22343722dc8bfcf1d2fd7b742f5b46287f87171e8143fc9b87db32c3d4"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.6.rb
+++ b/Casks/terraform-1.1.6.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.6" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.6/terraform_1.1.6_darwin_amd64.zip"
-    sha256 "dc515ad0d44c0543cc3e43e1139ecc1dab37536f5bce91eb63f2b4be483b84e4"
+    sha256 "7a499c1f08d89548ae4c0e829eea43845fa1bd7b464e7df46102b35e6081fe44"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.6/terraform_1.1.6_darwin_arm64.zip"
-    sha256 "065ab7df89e8ee64353746400469e6bad540c177f546efba40fdd0c04c9ca9f6"
+    sha256 "f06a14fdb610ec5a7f18bdbb2f67187230eb418329756732d970b6ca3dae12c3"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.7.rb
+++ b/Casks/terraform-1.1.7.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_darwin_amd64.zip"
-    sha256 "1929033b24e2ab21f2d28709a13e19b5c7e8ac9509daf8a87d200fd3a47cce3d"
+    sha256 "6e56eea328683541f6de0d5f449251a974d173e6d8161530956a20d9c239731a"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_darwin_arm64.zip"
-    sha256 "d457409a895cb5611e38425a8fc0804b782deec698cc4b9bbbf290bc67186d0f"
+    sha256 "8919ceee34f6bfb16a6e9ff61c95f4043c35c6d70b21de27e5a153c19c7eba9c"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.8.rb
+++ b/Casks/terraform-1.1.8.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.8" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_darwin_amd64.zip"
-    sha256 "a8fb67020be31b32728ecb08ddb9e2873cda6a587574761ab3d90cf447700e85"
+    sha256 "48f1f1e04d0aa8f5f1a661de95e3c2b8fd8ab16b3d44015372aff7693d36c2cf"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_darwin_arm64.zip"
-    sha256 "e5eb657f9e38be1c3934428a7021cf89fa51aba0e86321b4ccc6e76b971bd3b4"
+    sha256 "943e1948c4eae82cf8b490bb274939fe666252bbc146f098e7da65b23416264a"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.1.9.rb
+++ b/Casks/terraform-1.1.9.rb
@@ -7,10 +7,10 @@ cask "terraform-1.1.9" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_darwin_amd64.zip"
-    sha256 "26afa7cda355fbf32a2b4cfd9122a49132f1b68337691b91f05caa0b1023c388"
+    sha256 "685258b525eae94fb0b406faf661aa056d31666256bf28e625365a251cb89fdc"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_darwin_arm64.zip"
-    sha256 "80a230b56853f0fd50e12006c0d527da6a7f2e9974f25f7d372abfa2761ee3a3"
+    sha256 "39fac4be74462be86b2290dd09fe1092f73dfb48e2df92406af0e199cfa6a16c"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.0-alpha-20220328.rb
+++ b/Casks/terraform-1.2.0-alpha-20220328.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.0-alpha-20220328" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.0-alpha-20220328/terraform_1.2.0-alpha-20220328_darwin_amd64.zip"
-    sha256 "1b3a771235ab21e519c11f1a57aebce894938927d02c10d5cc75bc7022c405e8"
+    sha256 "6d7252fd9a2b43b27a217d0ff7bf38b1308b0cd6104918a308655332a789f8b9"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.0-alpha-20220328/terraform_1.2.0-alpha-20220328_darwin_arm64.zip"
-    sha256 "8dfcddd36d842194fcc79def3da1c9224abc982b60d9438710828b93f03ad660"
+    sha256 "5645246a227c922b2f82eb79ca23be8d2db901f1bcb5527373203c56637d4741"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.0-alpha20220413.rb
+++ b/Casks/terraform-1.2.0-alpha20220413.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.0-alpha20220413" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.0-alpha20220413/terraform_1.2.0-alpha20220413_darwin_amd64.zip"
-    sha256 "8642ee1d2cfea914f5ed982b2839c34d693d66b7e410a94774aaacd1934ba0e6"
+    sha256 "70fd32df5851a9a5d132119e0328708a4643109402813301fc2254fb6a7dd210"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.0-alpha20220413/terraform_1.2.0-alpha20220413_darwin_arm64.zip"
-    sha256 "4f1dd666857728915b91e3681f536945028fe5c3517a820fae503d39d0d74b38"
+    sha256 "1d4dbcc179c20d44a8fa7c0fec2f93078ccce94ad642bb1204041af2a0e53c76"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.0-beta1.rb
+++ b/Casks/terraform-1.2.0-beta1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.0-beta1/terraform_1.2.0-beta1_darwin_amd64.zip"
-    sha256 "10ec4ede5a27b00920b430240348017bbf4c0c72d0cbdbfaa72f8bc8eca453c7"
+    sha256 "da218c513f6062f565ca5f1749acca6cf93d80047d618c2d52b1ee31b3243d64"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.0-beta1/terraform_1.2.0-beta1_darwin_arm64.zip"
-    sha256 "dd3eb0103183e19d1370e6bad82bcbf4158efa658cb65fb0065e2e975812b76c"
+    sha256 "6dd843ee5e947ca93d731bccf147753c43dfcdfd7f5df1460e932822b5340bd3"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.0-rc1.rb
+++ b/Casks/terraform-1.2.0-rc1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.0-rc1/terraform_1.2.0-rc1_darwin_amd64.zip"
-    sha256 "028f8c331ea53946b987556c6e7544efc2bd8c23d6fa86ee851102b84b888c61"
+    sha256 "6891ce78a1b184484ea297d7ed7b82367b23191ff03bcf029d9f32209a18e7df"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.0-rc1/terraform_1.2.0-rc1_darwin_arm64.zip"
-    sha256 "14fa938ef5306b07e9b164998e763fd5ead9d3ff012d1f0f2e162cacfaeabfde"
+    sha256 "459b92dac3965a3888cae2d11930785b1e7c76189fd2e8d3feb1a0bbebb34ce0"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.0-rc2.rb
+++ b/Casks/terraform-1.2.0-rc2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.0-rc2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.0-rc2/terraform_1.2.0-rc2_darwin_amd64.zip"
-    sha256 "12e9dbf25d532e3d7ff422f90eca5118de970e24e28feb998e6e37fdc3cedf3c"
+    sha256 "74cbeb5ef960093dd3a37ddfed1af5c7659d54940a0d977c041f44dd616711a3"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.0-rc2/terraform_1.2.0-rc2_darwin_arm64.zip"
-    sha256 "149e813432378cb228b380b8ff9e46185fdba4193810bfd8f51dfce9317ca85e"
+    sha256 "f60029b6e08c5793c19268b44305d3ced89243b40b257bfa7e56c6feb443bed9"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.0.rb
+++ b/Casks/terraform-1.2.0.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.0/terraform_1.2.0_darwin_amd64.zip"
-    sha256 "cd60e3c04eccfceb655c60b0b1fa42cd07b23ecfabcbeebeab60c46b2b693dbf"
+    sha256 "1b102ba3bf0c60ff6cbee74f721bf8105793c1107a1c6d03dcab98d7079f0c77"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.0/terraform_1.2.0_darwin_arm64.zip"
-    sha256 "a35b308a05736c45a134ea52ead712a9cc91c4cdcfb859d02951190217ef26ef"
+    sha256 "f5e46cabe5889b60597f0e9c365cbc663e4c952c90a16c10489897c2075ae4f0"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.1.rb
+++ b/Casks/terraform-1.2.1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.1/terraform_1.2.1_darwin_amd64.zip"
-    sha256 "f9cf601b455df91fa8894d5f8169e3901cb562b7579c76d26bf429d03dad1437"
+    sha256 "31c0fd4deb7c6a77c08d2fdf59c37950e6df7165088c004e1dd7f5e09fbf6307"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.1/terraform_1.2.1_darwin_arm64.zip"
-    sha256 "46adfff9135f43635b2077ec642429a4ec3201169430c8de97ae31884ab40b74"
+    sha256 "70159b3e3eb49ee71193815943d9217c59203fd4ee8c6960aeded744094a2250"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.2.rb
+++ b/Casks/terraform-1.2.2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.2/terraform_1.2.2_darwin_amd64.zip"
-    sha256 "1568b1f7c22d1612d9608b28433506d3d28aaed11ab2c69e6c104855f3e00a55"
+    sha256 "1d22663c1ab22ecea774ae63aee21eecfee0bbc23b953206d889a5ba3c08525a"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.2/terraform_1.2.2_darwin_arm64.zip"
-    sha256 "78097a2e9e25b78cfa7a001eb5c4c27f13097051e6a3f340699febdbd12f62fa"
+    sha256 "b87716b55a3b10cced60db5285bae57aee9cc0f81c555dccdc4f54f62c2a3b60"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.3.rb
+++ b/Casks/terraform-1.2.3.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.3/terraform_1.2.3_darwin_amd64.zip"
-    sha256 "667fb8897a3db7af97457df2300f628916ac41c0283d1b4d4816c73c04123e36"
+    sha256 "bdc22658463237530dc120dadb0221762d9fb9116e7a6e0dc063d8ae649c431e"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.3/terraform_1.2.3_darwin_arm64.zip"
-    sha256 "05a6dcbd285723d63a7e0ad63c5bc25da58888f32d5f4cfc3f2e057f1d3080ae"
+    sha256 "6f06debac2ac54951464bf490e1606f973ab53ad8ba5decea76646e8f9309512"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.4.rb
+++ b/Casks/terraform-1.2.4.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.4/terraform_1.2.4_darwin_amd64.zip"
-    sha256 "4440024c9bd30bfa265eccf9822a41c5c9eb7b237d393f995bb3361db9c0c652"
+    sha256 "e7d2c66264a3da94854ae6ff692bbb9a1bc11c36bb5658e3ef19841388a07430"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.4/terraform_1.2.4_darwin_arm64.zip"
-    sha256 "0c3ff7c40441efc668705f7113ba4e16bc04aacb58fe0e2053432a27457afc03"
+    sha256 "c31754ff5553707ef9fd2f913b833c779ab05ce192eb14913f51816a077c6798"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.5.rb
+++ b/Casks/terraform-1.2.5.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.5/terraform_1.2.5_darwin_amd64.zip"
-    sha256 "6e109f82f15e5879cf003da75021f94266e54943fdfed4182a309e1159bc0e5c"
+    sha256 "2520fde736b43332b0c2648f4f6dde407335f322a3085114dc4f70e6e50eadc0"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.5/terraform_1.2.5_darwin_arm64.zip"
-    sha256 "0e322ffcd0d680a43788228a4e565379a7a6735a0d5fa4ae688cf89b415e020e"
+    sha256 "92ad40db4a0930bdf872d6336a7b3a18b17c6fd04d9fc769b554bf51c8add505"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.6.rb
+++ b/Casks/terraform-1.2.6.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.6" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.6/terraform_1.2.6_darwin_amd64.zip"
-    sha256 "31a228531d9cbcd964ca1d5eb0e0d9a1484619627503dcc1ae2a2c63d50ae975"
+    sha256 "d896d2776af8b06cd4acd695ad75913040ce31234f5948688fd3c3fde53b1f75"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.6/terraform_1.2.6_darwin_arm64.zip"
-    sha256 "d8e13e67f7303f68ca66e882f715d2af80d0124c9511b78f5ce799236654dc8e"
+    sha256 "c88ceb34f343a2bb86960e32925c5ec43b41922ee9ede1019c5cf7d7b4097718"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.7.rb
+++ b/Casks/terraform-1.2.7.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.7/terraform_1.2.7_darwin_amd64.zip"
-    sha256 "b413d0d3346370a741205fcfa180a4043e9c247ff0189708cf5a655373a1574a"
+    sha256 "74e47b54ea78685be24c84e0e17b22b56220afcdb24ec853514b3863199f01e4"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.7/terraform_1.2.7_darwin_arm64.zip"
-    sha256 "dd2d8143482f01e725a36f3864b78f518cae25e9480e5aeb1985637e65d5e56d"
+    sha256 "ec4e623914b411f8cc93a1e71396a1e7f1fe1e96bb2e532ba3e955d2ca5cc442"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.8.rb
+++ b/Casks/terraform-1.2.8.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.8" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.8/terraform_1.2.8_darwin_amd64.zip"
-    sha256 "5bad72d8dfca1cddaecfdc51858f035808ce268c201bee780982fbd8ce5814bb"
+    sha256 "efd3e21a9bb1cfa68303f8d119ea8970dbb616f5f99caa0fe21d796e0cd70252"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.8/terraform_1.2.8_darwin_arm64.zip"
-    sha256 "0affbfe6f8f791d6fb98ab5f91e975b0b1255dee9f172faee3ff6ab05c45a024"
+    sha256 "2c83bfea9e1c202c449e91bee06a804afb45cb8ba64a73da48fb0f61df51b327"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.2.9.rb
+++ b/Casks/terraform-1.2.9.rb
@@ -7,10 +7,10 @@ cask "terraform-1.2.9" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_darwin_amd64.zip"
-    sha256 "2c4d2b425a0680c6a4d65601a5f42f8b5c23e4ccd3332cf649ce14eaa646b967"
+    sha256 "84a678ece9929cebc34c7a9a1ba287c8b91820b336f4af8437af7feaa0117b7c"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_darwin_arm64.zip"
-    sha256 "91f51a352027f338b7673f23ee3c438ca8575933b7f58bfd7a92ffccf552158b"
+    sha256 "bc3b94b53cdf1be3c4988faa61aad343f48e013928c64bfc6ebeb61657f97baa"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-alpha20220608.rb
+++ b/Casks/terraform-1.3.0-alpha20220608.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-alpha20220608" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220608/terraform_1.3.0-alpha20220608_darwin_amd64.zip"
-    sha256 "ea5c01a73114461aaa57b33f99dbbe0e76ad9fd767f4954b18edade86f5e41b6"
+    sha256 "5917598e8fadf9d77e0201c0327e33a6123d6448530724417f4371a25944ed99"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220608/terraform_1.3.0-alpha20220608_darwin_arm64.zip"
-    sha256 "f6972d9f59e48046e6711afbfaa78c0d62a5654572a26570968c88742cebf3a0"
+    sha256 "1662a8e2b86c920c39ccf298bce464f7d85b05f16670b06fd370698f849d7f60"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-alpha20220622.rb
+++ b/Casks/terraform-1.3.0-alpha20220622.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-alpha20220622" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220622/terraform_1.3.0-alpha20220622_darwin_amd64.zip"
-    sha256 "e43e825551dc5e1db5c0317e199df223247ea2bdb34ae848ace186e975e807b6"
+    sha256 "2b6b1fcff71c20c408e1b3cbee8236645898e24e64006e6c999cb2ec9a6f610c"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220622/terraform_1.3.0-alpha20220622_darwin_arm64.zip"
-    sha256 "342a902b19c83e3f1ffe875821aa74449b5142ca11406b76b00c9fef44391c4f"
+    sha256 "757eee385bd67ca1878ffd51e2e61c156027ea371510bd10aea3d8f532b27983"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-alpha20220706.rb
+++ b/Casks/terraform-1.3.0-alpha20220706.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-alpha20220706" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220706/terraform_1.3.0-alpha20220706_darwin_amd64.zip"
-    sha256 "9f75c33f60b8578ae63139c2cd0891f98269a0601596625c0f2be5bc456d99e8"
+    sha256 "22260dc6eb0cd8a18f690b80299bf07dc5944876bbf6ec552837c4242303cb62"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220706/terraform_1.3.0-alpha20220706_darwin_arm64.zip"
-    sha256 "634d7bd3c5c6249d0ae9ce30ea173929be0ee0252e5233b5ad1bd32295f8fabb"
+    sha256 "b7eb881cf519383ac220b65207f90349bbff6064a037905a02855f5d8fcf7cec"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-alpha20220803.rb
+++ b/Casks/terraform-1.3.0-alpha20220803.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-alpha20220803" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220803/terraform_1.3.0-alpha20220803_darwin_amd64.zip"
-    sha256 "e745b07e19e5a58dac739d4f7f6945674d0c7f2fe2bde8d35ed214a2ffb657b5"
+    sha256 "dff45b9ebc241b7928a7f47c3eed0a2e2131f79de20e03ff4f258ee5c6c8dec1"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220803/terraform_1.3.0-alpha20220803_darwin_arm64.zip"
-    sha256 "d772192d847a94c55faa116727786d71cdeb16bb5602c3f30b1ddfd9ec56dc6d"
+    sha256 "dbbc1eb035fd144dc12e4c95549506473f550b696404ec374c912bd8f36d3930"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-alpha20220817.rb
+++ b/Casks/terraform-1.3.0-alpha20220817.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-alpha20220817" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220817/terraform_1.3.0-alpha20220817_darwin_amd64.zip"
-    sha256 "85bd822b98781c65aaa570acc7be58c9d2d50981f0bfd7370395ee98dcfce75a"
+    sha256 "78514bf223734e6d0c10697df509c63eb8327651b8746eeb1607a6b13cb6ec95"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-alpha20220817/terraform_1.3.0-alpha20220817_darwin_arm64.zip"
-    sha256 "06018d146f15436823cba72aa972f364e99a9c7b5f3958d2247412862abbd492"
+    sha256 "c463904ab2e53dfe9487dd3aa429de32ec300ea7a643b600759ed432d77f1713"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-beta1.rb
+++ b/Casks/terraform-1.3.0-beta1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-beta1/terraform_1.3.0-beta1_darwin_amd64.zip"
-    sha256 "d1eee240f0a86681c0bd34bd77a1a8cbd726dd2e22835414913985aaff285cee"
+    sha256 "3d07988b32e8a4d744765d0c78ebc64e43f737621d19cf05ef898f8537a12ae4"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-beta1/terraform_1.3.0-beta1_darwin_arm64.zip"
-    sha256 "953d6425b54c9722a79936d55df36bdf97ee2acab9d52817c02a5347be14ff8e"
+    sha256 "01efcf84b1d98c20e3675b76221f67b4f0d789f450ded6893bf09092640ebfd0"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0-rc1.rb
+++ b/Casks/terraform-1.3.0-rc1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0-rc1/terraform_1.3.0-rc1_darwin_amd64.zip"
-    sha256 "18d8c4a4384ecb11071e178ec58eeb1c82dde84793e7bf68a1e2ea2c3a8c46e5"
+    sha256 "7010d88700f8b64c647495f8909a46578f70c92178a9e0b710619c1dc825e9f8"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0-rc1/terraform_1.3.0-rc1_darwin_arm64.zip"
-    sha256 "3b825cefa3b3a7a6c3e5f78b5a36a20aabda2a1fc0e7874e50d226d0c3773d9d"
+    sha256 "9bb099ead7093701e55e23016cc476188ef19f538b16a69dacc2aeeb4382db30"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.0.rb
+++ b/Casks/terraform-1.3.0.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.0/terraform_1.3.0_darwin_amd64.zip"
-    sha256 "11ef95dc03e282463751113a153a07ff1fc63b9c3682085907fb110b69d5a347"
+    sha256 "80e55182d4495da867c93c25dc6ae29be83ece39d3225e6adedecd55b72d6bbf"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.0/terraform_1.3.0_darwin_arm64.zip"
-    sha256 "377249d76423c4f51751083f502092525b2de0adc931930a2f5841554f64ff4e"
+    sha256 "df703317b5c7f80dc7c61e46de4697c9f440e650a893623351ab5e184995b404"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.1.rb
+++ b/Casks/terraform-1.3.1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.1/terraform_1.3.1_darwin_amd64.zip"
-    sha256 "2be5311db5199fa3d900422496fd5ff954fc852700511c1e9804fdddc06b43fa"
+    sha256 "4282ebe6d1d72ace0d93e8a4bcf9a6f3aceac107966216355bb516b1c49cc203"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.1/terraform_1.3.1_darwin_arm64.zip"
-    sha256 "15a0d43c8458f628172151c2598bc8f4206a2a015c64a377d3dc6949cd605f13"
+    sha256 "f0514f29b08da2f39ba4fff0d7eb40093915c9c69ddc700b6f39b78275207d96"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.2.rb
+++ b/Casks/terraform-1.3.2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.2/terraform_1.3.2_darwin_amd64.zip"
-    sha256 "b5874e6a2b355f90331e0256737bbeeb85be59e477c32619555e98848b983765"
+    sha256 "3639461bbc712dc130913bbe632afb449fce8c0df692429d311e7cb808601901"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.2/terraform_1.3.2_darwin_arm64.zip"
-    sha256 "4e186e1caadad1e86281cb44f552d12f39186ae2ffe5852a525582b62353bcfc"
+    sha256 "80480acbfee2e2d0b094f721f7568a40b790603080d6612e19b797a16b8ba82d"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.3.rb
+++ b/Casks/terraform-1.3.3.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.3" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_darwin_amd64.zip"
-    sha256 "3f9dcc89206f7503c7f52465a48a97eac7ed0b2daf70404f2b422e42b0064e42"
+    sha256 "2b3cf653cd106becdea562b6c8d3f8939641e5626c5278729cbef81678fa9f42"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_darwin_arm64.zip"
-    sha256 "2fb68f9a4d1aadc55b10ddc56d07bbcf7a492b9e5c0525eb88e46abdf6eeb3b3"
+    sha256 "51e94ecf88059e8a53c363a048b658230f560574f99b0d8396ebacead894d159"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.4.rb
+++ b/Casks/terraform-1.3.4.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.4" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.4/terraform_1.3.4_darwin_amd64.zip"
-    sha256 "295de24b5f793192fa7aa02ff9e3a1c9486d14881a0a1f126a5ce4321ca8d8c4"
+    sha256 "2a75c69ec5ed8506658b266a40075256b62a7d245ff6297df7e48fa72af23879"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.4/terraform_1.3.4_darwin_arm64.zip"
-    sha256 "a02c19942edd0c5b2b4ac73d08e8c1c28238895d8afd8e98a7dab80cc2a2d920"
+    sha256 "a1f740f92afac6db84421a3ec07d9061c34a32f88b4b0b47d243de16c961169f"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.5.rb
+++ b/Casks/terraform-1.3.5.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.5" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.5/terraform_1.3.5_darwin_amd64.zip"
-    sha256 "d8b820f0ed8442819b9a8870efdd6bf54f1c5a392a278d7713fe0f1c05c4fdeb"
+    sha256 "e6c9836188265b20c2588e9c9d6b1727094b324a379337e68ba58a6d26be8b51"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.5/terraform_1.3.5_darwin_arm64.zip"
-    sha256 "6764387bb58ba0ac8c7dc9b3d2e93b97812ddd2b8e8ca56a930e7e2c601a3a12"
+    sha256 "fcec1cbff229fbe59b03257ba2451d5ad1f5129714f08ccf6372b2737647c063"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.6.rb
+++ b/Casks/terraform-1.3.6.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.6" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.6/terraform_1.3.6_darwin_amd64.zip"
-    sha256 "1e0b39ebb6c8bc5aa1bb38a4bc7dc0719f812e55adb6d1c9af33bc2527bb3497"
+    sha256 "13881fe0100238577394243a90c0631783aad21b77a9a7ee830404f86c0d37bb"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.6/terraform_1.3.6_darwin_arm64.zip"
-    sha256 "0df7916a7189939bfcd308e0c78b99bfd1ec5582d05aa109975837c29ceff700"
+    sha256 "dbff0aeeaeee877c254f5414bef5c9d186e159aa0019223aac678abad9442c53"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.7.rb
+++ b/Casks/terraform-1.3.7.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.7" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_darwin_amd64.zip"
-    sha256 "b00465acc7bdef57ba468b84b9162786e472dc97ad036a9e3526dde510563e2d"
+    sha256 "eeae48adcd55212b34148ed203dd5843e9b2a84a852a9877f3386fadb0514980"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_darwin_arm64.zip"
-    sha256 "6cda396999c9a27cb90c4902913c10ac0afe1bfceb957ed50a4298c5872979cf"
+    sha256 "01d553db5f7b4cf0729b725e4402643efde5884b1dabf5eb80af328ce5e447cf"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.8.rb
+++ b/Casks/terraform-1.3.8.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.8" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.8/terraform_1.3.8_darwin_amd64.zip"
-    sha256 "3cb29f95962947b0dbdf3f83338121879426d723ba60007e7c264c3c8a2add8f"
+    sha256 "1a27a6fac31ecb05de610daf61a29fe83d304d7c519d773afbf56c11c3b6276b"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.8/terraform_1.3.8_darwin_arm64.zip"
-    sha256 "4547a47be08350a3eb6e44fd28e957cf515c3a2b52e04f134366a08b1fbf03ec"
+    sha256 "873b05ac81645cd7289d6ccfd3e73d4735af1a453f2cd19da0650bdabf7d2eb6"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.3.9.rb
+++ b/Casks/terraform-1.3.9.rb
@@ -7,10 +7,10 @@ cask "terraform-1.3.9" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_darwin_amd64.zip"
-    sha256 "ca78815afd657f887de7f9b74014dc4bddffe80fd28028179b271a3c4f64f29a"
+    sha256 "a73326ea8fb06f6976597e005f8047cbd55ac76ed1e517303d8f6395db6c7805"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_darwin_arm64.zip"
-    sha256 "9df6fc8a9264bba1058e6e9383f43af2ee816088e61925e5bc45128ad8b6e9ad"
+    sha256 "d8a59a794a7f99b484a07a0ed2aa6520921d146ac5a7f4b1b806dcf5c4af0525"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.4.0-alpha20221109.rb
+++ b/Casks/terraform-1.4.0-alpha20221109.rb
@@ -7,10 +7,10 @@ cask "terraform-1.4.0-alpha20221109" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.4.0-alpha20221109/terraform_1.4.0-alpha20221109_darwin_amd64.zip"
-    sha256 "98f4cbc43bd66b9d85476c4c61561a7b812346740fadea3276afa74a3ee4daeb"
+    sha256 "3c34e6b6f2afd4847bf6bc76f3dc5630df655d0469a699f3cdf4d0ee11c7505f"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.4.0-alpha20221109/terraform_1.4.0-alpha20221109_darwin_arm64.zip"
-    sha256 "7116338bc56f5eeaf7db07e6868a79f766bbda1eefeaa9510a1d2d19cb92ceea"
+    sha256 "4537eb0228b27abb1bc1935e0ced1bb735b57d4e76a2f7d2ab243fe62fafd8c0"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.4.0-alpha20221207.rb
+++ b/Casks/terraform-1.4.0-alpha20221207.rb
@@ -7,10 +7,10 @@ cask "terraform-1.4.0-alpha20221207" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.4.0-alpha20221207/terraform_1.4.0-alpha20221207_darwin_amd64.zip"
-    sha256 "4ccc37ca714d6068a5624ec1b05ec219548270673823c04299bdd17973faf4cf"
+    sha256 "26c96a6ce8a199c3cce28c4da073c2d3349d48f3cdead3804a472bdeb6a31e5f"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.4.0-alpha20221207/terraform_1.4.0-alpha20221207_darwin_arm64.zip"
-    sha256 "0fe42b84847d9d320417e51f6b9918a8e4ff6a2ce2e3dabc8aa6a86372847964"
+    sha256 "9d222e60826e30ce72be4f1768573f279eeac3dba571f896bf737cafaae6e6be"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.4.0-beta1.rb
+++ b/Casks/terraform-1.4.0-beta1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.4.0-beta1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.4.0-beta1/terraform_1.4.0-beta1_darwin_amd64.zip"
-    sha256 "4737ae9826a6250e0f08e822bdd53600d1e56ae6736370fa7f18ac6e888ef164"
+    sha256 "08c54d8aa2429dfc289e2de06797d3f0f3b03e234e90a8e3c64bc69aa2f5f5c5"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.4.0-beta1/terraform_1.4.0-beta1_darwin_arm64.zip"
-    sha256 "f942574779d187e788aed2c9c2a9bf24287a955c739176d01216d16f63458a32"
+    sha256 "62de2c92d349626ecde3bbbb8645ac61247b6860f83d34a0ac5e93696ccc3813"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.4.0-beta2.rb
+++ b/Casks/terraform-1.4.0-beta2.rb
@@ -7,10 +7,10 @@ cask "terraform-1.4.0-beta2" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.4.0-beta2/terraform_1.4.0-beta2_darwin_amd64.zip"
-    sha256 "da70cbc74236b1fb02a42ca6b459e12a54ed28a93bf006da1bf90d6a457b8977"
+    sha256 "94b42aabedb8b57fa022d7d4720ed45dc67cb86c91e3dc182eb2aef70bb33408"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.4.0-beta2/terraform_1.4.0-beta2_darwin_arm64.zip"
-    sha256 "5bce62ba8a9723c75171e010f1336438a16656ab06d8f6f0d1ba3b3d40b70b98"
+    sha256 "917bbbf62657640f3196125b232cc5503b5dcfbba23001ade03164ef4a4f9ea0"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.4.0-rc1.rb
+++ b/Casks/terraform-1.4.0-rc1.rb
@@ -7,10 +7,10 @@ cask "terraform-1.4.0-rc1" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.4.0-rc1/terraform_1.4.0-rc1_darwin_amd64.zip"
-    sha256 "b2feca9468e3ae50d53048bbab98a94ec323594009b2fa9b7a3f4739749cd883"
+    sha256 "db875cd9b42a4ea285a9365a329e42de3affba53cdcbd96f86588546c6b06fff"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.4.0-rc1/terraform_1.4.0-rc1_darwin_arm64.zip"
-    sha256 "9e7e273aafb524efba6b849f9514c237434215c1a4819e8aadc2fab08fe28b82"
+    sha256 "46ac4bd57da743c70dac00bd3dccfa25fcbf7cfaa520b4c1cd504d669776d107"
   end
 
   depends_on arch: [:x86_64, :arm64]

--- a/Casks/terraform-1.4.0.rb
+++ b/Casks/terraform-1.4.0.rb
@@ -7,10 +7,10 @@ cask "terraform-1.4.0" do
   case Hardware::CPU.arch
   when :x86_64
     url "https://releases.hashicorp.com/terraform/1.4.0/terraform_1.4.0_darwin_amd64.zip"
-    sha256 "b063c2018ed6229a6d92defee0b2a115a0a18169ed02e93ecf3899ca3e2a87de"
+    sha256 "e897a4217f1c3bfe37c694570dcc6371336fbda698790bb6b0547ec8daf1ffb3"
   when :arm64
     url "https://releases.hashicorp.com/terraform/1.4.0/terraform_1.4.0_darwin_arm64.zip"
-    sha256 "ec02ccdcc368ce307d03c1e981f3a863d9c07b312635d4aca24159ada7657562"
+    sha256 "d4a1e564714c6acf848e86dc020ff182477b49f932e3f550a5d9c8f5da7636fb"
   end
 
   depends_on arch: [:x86_64, :arm64]


### PR DESCRIPTION
I noticed today that `chtf 1.3.9` (among many other versions) shows a SHA256 mismatch error on macOS.

Investigating further, it seems HashiCorp recently re-signed their packages. The situation looks similar to the one mentioned in #163, with a follow-up incident raised by HashiCorp: https://status.hashicorp.com/incidents/f7bz2z28w6pv

> During this time, we will be publishing apple artifacts (darwin binaries, dmg’s, and pkg’s) and updated shasums files that have been resigned and notarized. This is needed to resolve an issue where an incorrect codesign identifier was set across apple artifacts during our previous resigning effort on January 23rd

To generate this change I fetched all shasums again with:

```
UPDATE_ALL=yes ./scripts/add_new_terraform_casks
```
