### PR TITLE
Fix Cask format for the latest requirements

### DIFF
--- a/Casks/terraform-0-1-0.rb
+++ b/Casks/terraform-0-1-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-1-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.1.0"
+
+  arch = "amd64"
+  sha256 "309aed0ed61586e2682f58b77781f8e9805745a5edd1aebcddf883c9f624a0b9"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-1-1.rb
+++ b/Casks/terraform-0-1-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-1-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.1.1"
+
+  arch = "amd64"
+  sha256 "1387eca09fcad8571f02d2f34b79d7cff5f420da8cc52e9b0841696461c99b38"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-10-0-beta1.rb
+++ b/Casks/terraform-0-10-0-beta1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-10-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.10.0-beta1"
+
+  arch = "amd64"
+  sha256 "8170d52bd55bd80744aacd96ae8d87b39e29ed3d2d2853c9cb66ca62b5e295c6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-10-0-beta2.rb
+++ b/Casks/terraform-0-10-0-beta2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-10-0-beta2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.10.0-beta2"
+
+  arch = "amd64"
+  sha256 "6138b4177e392e759bebc378cfe3a8dbbab6eae43214269464a005597aed85c6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-10-0-rc1.rb
+++ b/Casks/terraform-0-10-0-rc1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-10-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.10.0-rc1"
+
+  arch = "amd64"
+  sha256 "cb8b8c7abc291467bd432cbadb993b6972538c0d438cd6933d29c5c0702574d2"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-10-0.rb
+++ b/Casks/terraform-0-10-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-10-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.10.0"
+
+  arch = "amd64"
+  sha256 "1584dc21ad5ac1dc0d9a2876542a85d092778d00a0622622c28f8740abadddb9"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-10-1.rb
+++ b/Casks/terraform-0-10-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-10-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.10.1"
+
+  arch = "amd64"
+  sha256 "5aae5125140b6cb39532360bd725fd33a9224b8358140291ff1d34a086dd646b"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-10-2.rb
+++ b/Casks/terraform-0-10-2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-10-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.10.2"
+
+  arch = "amd64"
+  sha256 "1ad6bad0349a3bcda8264746a3db0a39875c2cd93e3418393cc082bbb4812541"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-10-3.rb
+++ b/Casks/terraform-0-10-3.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-10-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.10.3"
+
+  arch = "amd64"
+  sha256 "6d7c51b8b8eee81b07c6b594077e0af95be518ed88b312bd3989c37b2924c2e6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-10-4.rb
+++ b/Casks/terraform-0-10-4.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-10-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.10.4"
+
+  arch = "amd64"
+  sha256 "70885c572f7bc54361c77d4839303210579db5875636711f621f6763574c1237"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-10-5.rb
+++ b/Casks/terraform-0-10-5.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-10-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.10.5"
+
+  arch = "amd64"
+  sha256 "d39ce30b7aa77834d3000173d95df476c0fcfea8114825d8276c38277d3a7436"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-10-6.rb
+++ b/Casks/terraform-0-10-6.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-10-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.10.6"
+
+  arch = "amd64"
+  sha256 "a37f190cfcac21fa2343ec7e3112137d27fb9286c9f5c128547c6221502442c9"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-10-7.rb
+++ b/Casks/terraform-0-10-7.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-10-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.10.7"
+
+  arch = "amd64"
+  sha256 "60924d17e40be4b055629719a1f633736cca70c4506b8f7e32fa17e0d6e57477"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-10-8.rb
+++ b/Casks/terraform-0-10-8.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-10-8" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.10.8"
+
+  arch = "amd64"
+  sha256 "3f05acdf0a9e04ba7e3bda18521feb0b310462dcce62c454854a40519b1695ed"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-0-beta1.rb
+++ b/Casks/terraform-0-11-0-beta1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.0-beta1"
+
+  arch = "amd64"
+  sha256 "5a8f9118bf99285aa41c60b150fb628ec6a1bc49293663fd2255eedc5934f379"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-0-rc1.rb
+++ b/Casks/terraform-0-11-0-rc1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.0-rc1"
+
+  arch = "amd64"
+  sha256 "c7bbc03a40c089077e77befb3405c3fdf456f46e7b3bdafc50e48bfcc6f7b5a5"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-0.rb
+++ b/Casks/terraform-0-11-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.0"
+
+  arch = "amd64"
+  sha256 "0d5f7ffcfd34fe58ed25fe48650f1c9ac1d9e15983af43deaeffc6d0a88ba346"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-1.rb
+++ b/Casks/terraform-0-11-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.1"
+
+  arch = "amd64"
+  sha256 "f5e04d3886e9a427490d1aa857a61b5a87d08dc26fb8637e3eaa72b30562c330"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-10.rb
+++ b/Casks/terraform-0-11-10.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-10" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.10"
+
+  arch = "amd64"
+  sha256 "cb5ae1fa5bed45d81d79d427cd1dd84ed7c04f712c72b420003e28f522a77a78"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-11.rb
+++ b/Casks/terraform-0-11-11.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-11" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.11"
+
+  arch = "amd64"
+  sha256 "6b6e8253b678554c67d717c42209fd857bfe64a1461763c05d3d1d85c6f618d3"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-12-beta1.rb
+++ b/Casks/terraform-0-11-12-beta1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-12-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.12-beta1"
+
+  arch = "amd64"
+  sha256 "8c1f4f975bf4bba6725e6e1cbc69c4a7764a3fb6dc6aebf2e718456eed6405a9"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-12.rb
+++ b/Casks/terraform-0-11-12.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-12" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.12"
+
+  arch = "amd64"
+  sha256 "316fa873b26463f3e015db11dba00eab1839338f930f1352dbab2d0bcd0828a5"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-13.rb
+++ b/Casks/terraform-0-11-13.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-13" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.13"
+
+  arch = "amd64"
+  sha256 "e9988443da39e5d81a5f7f1b6a5d97b25e2a1151d9be76cdc2e380df97e57856"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-14.rb
+++ b/Casks/terraform-0-11-14.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-14" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.14"
+
+  arch = "amd64"
+  sha256 "829bdba148afbd61eab4aafbc6087838f0333d8876624fe2ebc023920cfc2ad5"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-15-oci.rb
+++ b/Casks/terraform-0-11-15-oci.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-15-oci" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.15-oci"
+
+  arch = "amd64"
+  sha256 "e219eeee655797d485005014f3833ebfb5484423fa770cf462a03c36f3cfa359"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-15.rb
+++ b/Casks/terraform-0-11-15.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-15" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.15"
+
+  arch = "amd64"
+  sha256 "9c3214dcaa277c3773d52d514a76959c82896a1661061b7e5f9523c38add10b7"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-2.rb
+++ b/Casks/terraform-0-11-2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.2"
+
+  arch = "amd64"
+  sha256 "ff5c3c4bcfe84e011b96a2232704b2db196383ce5d4a32e47956c883ddc94bac"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-3.rb
+++ b/Casks/terraform-0-11-3.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.3"
+
+  arch = "amd64"
+  sha256 "183078bf230e517e6f41e47d6e7d3b61093c6bb5a2b85958c01a4cf3949b7c14"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-4.rb
+++ b/Casks/terraform-0-11-4.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.4"
+
+  arch = "amd64"
+  sha256 "c328b8d60840b96641f519deb85601cb1f2cce458c7bdb7786712471234ac0c5"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-5.rb
+++ b/Casks/terraform-0-11-5.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.5"
+
+  arch = "amd64"
+  sha256 "0af78baf9b1a249544cc0b17d6b7abb32cc513a554d1f7dcc85c873e2af93586"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-6.rb
+++ b/Casks/terraform-0-11-6.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.6"
+
+  arch = "amd64"
+  sha256 "edbdde7ca769a5c7ca1c048bd5729b1f70d556b4ee61287dff5057660bc1f64d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-7.rb
+++ b/Casks/terraform-0-11-7.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.7"
+
+  arch = "amd64"
+  sha256 "6514a8fe5a344c5b8819c7f32745cd571f58092ffc9bbe9ea3639799b97ced5f"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-8.rb
+++ b/Casks/terraform-0-11-8.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-8" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.8"
+
+  arch = "amd64"
+  sha256 "98c168b06e8b4058c66e044e3744d49956ce7bc3664dc1679a33f8fffc84564d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-9-beta1.rb
+++ b/Casks/terraform-0-11-9-beta1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-9-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.9-beta1"
+
+  arch = "amd64"
+  sha256 "a95ac475acd068a876a1068fa90cb2e9370e1c28e8c7fc57b7db016629b533be"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-11-9.rb
+++ b/Casks/terraform-0-11-9.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-11-9" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.11.9"
+
+  arch = "amd64"
+  sha256 "1b5a0c916f547c396959b8c303f3bfa7a2e936c78f002bf42e532c9254fd6d75"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-0-alpha1.rb
+++ b/Casks/terraform-0-12-0-alpha1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-0-alpha1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.0-alpha1"
+
+  arch = "amd64"
+  sha256 "2797b82e22c5557da604b6b727cb8112844a92c81b16840980a43ed78d9e0512"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-0-alpha2.rb
+++ b/Casks/terraform-0-12-0-alpha2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-0-alpha2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.0-alpha2"
+
+  arch = "amd64"
+  sha256 "859fa4459f8cc8b4cda026b71cd7c8011fafc765e570fbdf3abe9fbcad44d59c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-0-beta1.rb
+++ b/Casks/terraform-0-12-0-beta1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.0-beta1"
+
+  arch = "amd64"
+  sha256 "2da57018c25ada511b7131d85257f534030eddf23b347663af4c4ca89d3d9220"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-0-beta2.rb
+++ b/Casks/terraform-0-12-0-beta2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-0-beta2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.0-beta2"
+
+  arch = "amd64"
+  sha256 "6be99d150329e55ae636e40500e96a6243a6a00d74126eef9fdb47f17a1070d7"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-0-rc1.rb
+++ b/Casks/terraform-0-12-0-rc1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.0-rc1"
+
+  arch = "amd64"
+  sha256 "cb10093fe8b14771047314b547c7710e363199c40e129bb7e3b4886e3f3b3ca6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-0.rb
+++ b/Casks/terraform-0-12-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.0"
+
+  arch = "amd64"
+  sha256 "9dbee9dea660ea64352f8ddf2539e60d1c414210e9c4a29c8585926fef366be1"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-1.rb
+++ b/Casks/terraform-0-12-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.1"
+
+  arch = "amd64"
+  sha256 "3c5b0aa8f3acf477a5d5ae997174bd16d49bb0789915b5a40a6deb39692a5c8d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-10.rb
+++ b/Casks/terraform-0-12-10.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-10" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.10"
+
+  arch = "amd64"
+  sha256 "70692a1221848c8a6f29972e89eaaf400ecc2aa33708b9ed14a17957e3845533"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-11.rb
+++ b/Casks/terraform-0-12-11.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-11" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.11"
+
+  arch = "amd64"
+  sha256 "31c7451366605a9d6a6dc41ae0ab29ec186eebeed13e05349f578eaac7692596"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-12.rb
+++ b/Casks/terraform-0-12-12.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-12" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.12"
+
+  arch = "amd64"
+  sha256 "abc3a0b5184259be2b9f744baae0d3709fae0e38112e36d35ff9debb43375e97"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-13.rb
+++ b/Casks/terraform-0-12-13.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-13" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.13"
+
+  arch = "amd64"
+  sha256 "77d9e73edccc9cc3c7b5e0f1c84a90f0f18b55359aff9181faf636c9fb14c15a"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-14.rb
+++ b/Casks/terraform-0-12-14.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-14" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.14"
+
+  arch = "amd64"
+  sha256 "23de0d866199d0d305084c146969115318773921fcf22c1d78503bdafec4c44d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-15.rb
+++ b/Casks/terraform-0-12-15.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-15" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.15"
+
+  arch = "amd64"
+  sha256 "4f238094e332c16ee7bcffe234ae71cf355eb7d54f4ae9f531af0e2d374cecbc"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-16.rb
+++ b/Casks/terraform-0-12-16.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-16" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.16"
+
+  arch = "amd64"
+  sha256 "8d3db354320078e0ceb0beec97ca1a0934378ef8ede28e2fe76481c171267762"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-17.rb
+++ b/Casks/terraform-0-12-17.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-17" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.17"
+
+  arch = "amd64"
+  sha256 "130235cad547ab0f9849dedbd020528e0c76798bd53528a3cd63c7ce51290e8f"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-18.rb
+++ b/Casks/terraform-0-12-18.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-18" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.18"
+
+  arch = "amd64"
+  sha256 "3a1416cb61322d327c34dd6858c5b61048a9142cf9038b5d008e1527fa74a3fc"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-19.rb
+++ b/Casks/terraform-0-12-19.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-19" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.19"
+
+  arch = "amd64"
+  sha256 "36a013a207a8fd0f23d07ee2cf8fb1ac0e547fccf94215e9d2b5d77862e7f758"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-2.rb
+++ b/Casks/terraform-0-12-2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.2"
+
+  arch = "amd64"
+  sha256 "f0cc23bc6ec1a5adc4043108ff5c79c2bddcdc70b056bd207defca1ae386d477"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-20.rb
+++ b/Casks/terraform-0-12-20.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-20" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.20"
+
+  arch = "amd64"
+  sha256 "67d143f187d0bc7293a40cbbf465b4fdd585669252c522a9b0b96544e0987c1d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-21.rb
+++ b/Casks/terraform-0-12-21.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-21" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.21"
+
+  arch = "amd64"
+  sha256 "2303c361e66ae64ccbf09b0e1c50cea4f28727e913c52d930e8a885d79c099f3"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-22.rb
+++ b/Casks/terraform-0-12-22.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-22" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.22"
+
+  arch = "amd64"
+  sha256 "7e2c6d74fb3ff141976567b3903d3ffc6721230d3dd4e346e4c09de146a947bb"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-23.rb
+++ b/Casks/terraform-0-12-23.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-23" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.23"
+
+  arch = "amd64"
+  sha256 "12293764366ade518e2022c6ad981712e029e24bdbf3e1d5822de82dec1a6dbd"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-24.rb
+++ b/Casks/terraform-0-12-24.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-24" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.24"
+
+  arch = "amd64"
+  sha256 "d97e5bb1064aa2da0b82865ecf588bea20afdd6bfaf0692fafcb9ff765de9b2b"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-25.rb
+++ b/Casks/terraform-0-12-25.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-25" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.25"
+
+  arch = "amd64"
+  sha256 "d3592d13da863f65b57be78f9ab264b3a738cc0b972c7fa02996d5932237e44d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-26.rb
+++ b/Casks/terraform-0-12-26.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-26" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.26"
+
+  arch = "amd64"
+  sha256 "5dd8deea9060d2d90b748425cde9063620131f02922a993e3d925048375d9b29"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-27.rb
+++ b/Casks/terraform-0-12-27.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-27" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.27"
+
+  arch = "amd64"
+  sha256 "06eaab0bc3451b4d2f7feb47f5587399702d19b9044f5705dc76ad77b401e26f"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-28.rb
+++ b/Casks/terraform-0-12-28.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-28" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.28"
+
+  arch = "amd64"
+  sha256 "2c144bdd455d2cf059ff2e6db048667d6e093f29de172188aad176325ca5dc68"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-29.rb
+++ b/Casks/terraform-0-12-29.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-29" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.29"
+
+  arch = "amd64"
+  sha256 "a920c9fcf912b5f83a4e57cb8ab7afbe5615ec54edd893271c8d271a4d945592"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-3.rb
+++ b/Casks/terraform-0-12-3.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.3"
+
+  arch = "amd64"
+  sha256 "f0e09af8ce413ec9a949c00ea6645cd8169a03412e545a3375adf91c3ad8c7ad"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-30.rb
+++ b/Casks/terraform-0-12-30.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-30" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.30"
+
+  arch = "amd64"
+  sha256 "7d1a1d12bedce7b2c474495db0d777389a4e9b02181ad4db9bda3511e586f8e0"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-31.rb
+++ b/Casks/terraform-0-12-31.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-31" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.31"
+
+  arch = "amd64"
+  sha256 "ebd96d0c1fc206480a61a190059d3e8aebdfa8733bfa309d7a34ad5a3e0eb322"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-4.rb
+++ b/Casks/terraform-0-12-4.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.4"
+
+  arch = "amd64"
+  sha256 "e19691d775849888a0695a07e52a884dc617ca2100759eca5bbe4d0f428a7bc3"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-5.rb
+++ b/Casks/terraform-0-12-5.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.5"
+
+  arch = "amd64"
+  sha256 "e0afcf6f6401e9eaab0be588b55b5226549253854acc1d0cde331b8ca54727e0"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-6.rb
+++ b/Casks/terraform-0-12-6.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.6"
+
+  arch = "amd64"
+  sha256 "7168dfa057d9aed7ea3f111d87294f263e341c8b848e776bc13d169ddf2926c7"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-7.rb
+++ b/Casks/terraform-0-12-7.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.7"
+
+  arch = "amd64"
+  sha256 "17471e64e85e91c9309e9e17df7b8740664b2b58b6f1d6088dfc400a995b0413"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-8.rb
+++ b/Casks/terraform-0-12-8.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-8" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.8"
+
+  arch = "amd64"
+  sha256 "6f472c3cff1b679c43ebf128e164d35fc15ff95f10a8a02f9027fd60a0bcab6f"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-12-9.rb
+++ b/Casks/terraform-0-12-9.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-12-9" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.12.9"
+
+  arch = "amd64"
+  sha256 "d8314eda99d48f17c737643eb1804c654c6e08c53465dd0fa8d8348c77150e6b"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-13-0-beta1.rb
+++ b/Casks/terraform-0-13-0-beta1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-13-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.13.0-beta1"
+
+  arch = "amd64"
+  sha256 "e04f099544df4725b16e4c8835c08f880cf960441bebd9baea868ea4d39f6f6f"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-13-0-beta2.rb
+++ b/Casks/terraform-0-13-0-beta2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-13-0-beta2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.13.0-beta2"
+
+  arch = "amd64"
+  sha256 "44c3afe6bb53020a82341c26ac36612a32a135163ff490aa778e9eefa53bf0f3"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-13-0-beta3.rb
+++ b/Casks/terraform-0-13-0-beta3.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-13-0-beta3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.13.0-beta3"
+
+  arch = "amd64"
+  sha256 "a4916de8ba4fd28699d4cdab540f9f58cc8941966d276c4ba12f4afdeffd029d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-13-0-rc1.rb
+++ b/Casks/terraform-0-13-0-rc1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-13-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.13.0-rc1"
+
+  arch = "amd64"
+  sha256 "2bbbe855e1e09f03ff06334a7f0b3ba15506e6ac4deb25938f34bb210540a687"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-13-0.rb
+++ b/Casks/terraform-0-13-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-13-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.13.0"
+
+  arch = "amd64"
+  sha256 "1ffcd96037faffad5c8692fd989d5f261fdddc8b0fede3996aa09b7bfe6b1b01"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-13-1.rb
+++ b/Casks/terraform-0-13-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-13-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.13.1"
+
+  arch = "amd64"
+  sha256 "8c9bab51223e7039572763326267c1989d1727f552b3728f586cfa868b01b537"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-13-2.rb
+++ b/Casks/terraform-0-13-2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-13-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.13.2"
+
+  arch = "amd64"
+  sha256 "8f2ef6fe5727014dde0496d88dffab5fcafd0c35138466d19de2dd6147d96b90"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-13-3.rb
+++ b/Casks/terraform-0-13-3.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-13-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.13.3"
+
+  arch = "amd64"
+  sha256 "4a613dc18ff8cfac525a59cc0e78216fa0a9ecd63e6ac45603561ceb72f6d772"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-13-4.rb
+++ b/Casks/terraform-0-13-4.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-13-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.13.4"
+
+  arch = "amd64"
+  sha256 "5011d509a23ed6e2010a25f0449552b03822d7ef9b8b48f8a2f3277f2f34b736"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-13-5.rb
+++ b/Casks/terraform-0-13-5.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-13-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.13.5"
+
+  arch = "amd64"
+  sha256 "6ede2ffced90d7ad0050ac5ff4c617ef7f07d1d2522b6ba83a07e5e980c28775"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-13-6.rb
+++ b/Casks/terraform-0-13-6.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-13-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.13.6"
+
+  arch = "amd64"
+  sha256 "dd933ecd25f38c23e2f7e70503912362429ce251d4d5ef17f4be55bbfd55bafd"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-13-7.rb
+++ b/Casks/terraform-0-13-7.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-13-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.13.7"
+
+  arch = "amd64"
+  sha256 "60f3561eb11fa6c61321d6c8b698023eb7b74dc1a49210bd5f5acb03f453db9b"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-0-alpha20200910.rb
+++ b/Casks/terraform-0-14-0-alpha20200910.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-0-alpha20200910" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.0-alpha20200910"
+
+  arch = "amd64"
+  sha256 "e75122707182459bd997aafe6b5559260d3429ab09b11547de78b053f4b674ce"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-0-alpha20200923.rb
+++ b/Casks/terraform-0-14-0-alpha20200923.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-0-alpha20200923" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.0-alpha20200923"
+
+  arch = "amd64"
+  sha256 "adc3dd2d8f4e53d66b09dd9ee9b57e48a60aab34e7bfc013867ed278648594ac"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-0-alpha20201007.rb
+++ b/Casks/terraform-0-14-0-alpha20201007.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-0-alpha20201007" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.0-alpha20201007"
+
+  arch = "amd64"
+  sha256 "542f89fd3005dfe9e7d2583182f78872def6a82dda31acafde3f0f8fa99f5098"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-0-beta1.rb
+++ b/Casks/terraform-0-14-0-beta1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.0-beta1"
+
+  arch = "amd64"
+  sha256 "8ecff69cebdd6f5bb7448bff82813eb978c1c3714976e38ca7ef8115f259f3f7"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-0-beta2.rb
+++ b/Casks/terraform-0-14-0-beta2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-0-beta2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.0-beta2"
+
+  arch = "amd64"
+  sha256 "b6bbb9b918dad1dabfcc8be5d0c143ef03d27f981b1af17470b45c04604a93cb"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-0-rc1.rb
+++ b/Casks/terraform-0-14-0-rc1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.0-rc1"
+
+  arch = "amd64"
+  sha256 "4fff2d849d96c6278188dfe10d371863253b8f789c98d17c8cffc4eda738810e"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-0.rb
+++ b/Casks/terraform-0-14-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.0"
+
+  arch = "amd64"
+  sha256 "6bbf84885f15688c427726306331a2599af3041bb86d9330819d435db516e15c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-1.rb
+++ b/Casks/terraform-0-14-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.1"
+
+  arch = "amd64"
+  sha256 "3211e5858a7cf2f81f46a3ff2fa577c70998e0af22b589eb4cfa8057fa27f576"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-10.rb
+++ b/Casks/terraform-0-14-10.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-10" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.10"
+
+  arch = "amd64"
+  sha256 "ac56b87611ea4cff4b1f21d320d38a46dac0e4730d1d90509f46b0bcb2f5c50e"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-11.rb
+++ b/Casks/terraform-0-14-11.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-11" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.11"
+
+  arch = "amd64"
+  sha256 "88d266a53b4c09e9778123f274351d7f6e48c08c12edaece8f4e360ade3bd847"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-2.rb
+++ b/Casks/terraform-0-14-2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.2"
+
+  arch = "amd64"
+  sha256 "f26da93e17f347b345555e74d33f3aa79c60ac77efc995e1eb6018ffa06cb70c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-3.rb
+++ b/Casks/terraform-0-14-3.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.3"
+
+  arch = "amd64"
+  sha256 "577f5bdb4dc0828737389b634b07895e971c7860b1e01bc765fdd9563c5ce1a4"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-4.rb
+++ b/Casks/terraform-0-14-4.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.4"
+
+  arch = "amd64"
+  sha256 "9efab671f69dd277ab961aff36c17bc2c33a927246b51c55df3816bfd3184966"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-5.rb
+++ b/Casks/terraform-0-14-5.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.5"
+
+  arch = "amd64"
+  sha256 "2edf2491d3b6a98949bb83b427713fdae14780ca9eeb2d6504e4a4325ba5383a"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-6.rb
+++ b/Casks/terraform-0-14-6.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.6"
+
+  arch = "amd64"
+  sha256 "d83b0427138749ae105ae10fa65cbb81027b5efc970bacd3911c674af932e27c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-7.rb
+++ b/Casks/terraform-0-14-7.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.7"
+
+  arch = "amd64"
+  sha256 "bd4afbb92cfc99f3f7e81412536e1aa9bafd6544a87454286d9e9f6ab446179a"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-8.rb
+++ b/Casks/terraform-0-14-8.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-8" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.8"
+
+  arch = "amd64"
+  sha256 "596363941c5acfb05d81f6fe8813f007427de0e976972bdd60106bf4e6d8eb54"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-14-9.rb
+++ b/Casks/terraform-0-14-9.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-14-9" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.14.9"
+
+  arch = "amd64"
+  sha256 "a62e812d068b44b8a93d8b2fc024850ad69cb5ce7f9b0bfc68e836b90a06693d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-0-alpha20210107.rb
+++ b/Casks/terraform-0-15-0-alpha20210107.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-0-alpha20210107" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.0-alpha20210107"
+
+  arch = "amd64"
+  sha256 "b5a95586cead146ef532642079dd3e4bb93f0ab785b5bc57c5c6259eb0da2d37"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-0-alpha20210127.rb
+++ b/Casks/terraform-0-15-0-alpha20210127.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-0-alpha20210127" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.0-alpha20210127"
+
+  arch = "amd64"
+  sha256 "ee7cf15916da97bd0959b2928bd1c23afd9d4e6a06a9529ee398d79dd490a452"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-0-alpha20210210.rb
+++ b/Casks/terraform-0-15-0-alpha20210210.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-0-alpha20210210" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.0-alpha20210210"
+
+  arch = "amd64"
+  sha256 "3fcccd708947e8d8ac54a6a5b9b4835c410336506aa3ce25579c40c2df854423"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-0-beta1.rb
+++ b/Casks/terraform-0-15-0-beta1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.0-beta1"
+
+  arch = "amd64"
+  sha256 "bf4484361e9b2348b2f61856855c90f010c3cba927851dfcea3a3ac027306519"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-0-beta2.rb
+++ b/Casks/terraform-0-15-0-beta2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-0-beta2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.0-beta2"
+
+  arch = "amd64"
+  sha256 "b669d9b4322f70f292761f62c43751d1a2ce583381336428c3adda3094874dbc"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-0-rc1.rb
+++ b/Casks/terraform-0-15-0-rc1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.0-rc1"
+
+  arch = "amd64"
+  sha256 "57bd815c2e0ba101ab7bce3d00585430ec2e74d289dfbbe47e336551c48f914f"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-0-rc2.rb
+++ b/Casks/terraform-0-15-0-rc2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-0-rc2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.0-rc2"
+
+  arch = "amd64"
+  sha256 "73347bb7965b6681b7dc10f45d0eeec28b5916cbadb62ff97e9a885956ab9201"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-0.rb
+++ b/Casks/terraform-0-15-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.0"
+
+  arch = "amd64"
+  sha256 "de9c15e25b5f60fd6cb4bdabf16cff252977a97afde6cfda8d465ef28be5fd81"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-1.rb
+++ b/Casks/terraform-0-15-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.1"
+
+  arch = "amd64"
+  sha256 "7f457dd1268ad616b9f832c4b731456676a860a3ecf4b2751957a0e7cf38924d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-2.rb
+++ b/Casks/terraform-0-15-2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.2"
+
+  arch = "amd64"
+  sha256 "74b7317085f86b34c7dc1a1a97d8f3f1b418a56d1b3bf51c869c432851fa1138"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-3.rb
+++ b/Casks/terraform-0-15-3.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.3"
+
+  arch = "amd64"
+  sha256 "2521b478aef5b8c9f374d0caa265bee2a03f31f290ee8d048eb2f110eb4ffc8e"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-4.rb
+++ b/Casks/terraform-0-15-4.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.4"
+
+  arch = "amd64"
+  sha256 "9092c017257ead94223418dac7165541228e773463b476e0803848be4f3169a4"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-15-5.rb
+++ b/Casks/terraform-0-15-5.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-15-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.15.5"
+
+  arch = "amd64"
+  sha256 "5ad75ed3def05f36b5c5dab97dee00b5d3d86be9f9dcd205b48136312505f3fc"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-2-0.rb
+++ b/Casks/terraform-0-2-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-2-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.2.0"
+
+  arch = "amd64"
+  sha256 "32c1c5d2df88c612207e9b5edea6f0f4c3bbdc8f2ae5f8c577ede2055548136b"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-2-1.rb
+++ b/Casks/terraform-0-2-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-2-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.2.1"
+
+  arch = "amd64"
+  sha256 "028076fa5b074d2b2457f857fe8f2182a8ef7a35c15b8c3b18a129df60790ea7"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-2-2.rb
+++ b/Casks/terraform-0-2-2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-2-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.2.2"
+
+  arch = "amd64"
+  sha256 "1b4581e41e05145d2e9707cad5313636120a80b04cb796a503b3bfe59b6901d2"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-3-0.rb
+++ b/Casks/terraform-0-3-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-3-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.3.0"
+
+  arch = "amd64"
+  sha256 "6c8eb551381eb331c0ef3f5615a60529bc45de1c702b02ed4dfa523cffa26084"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-3-1.rb
+++ b/Casks/terraform-0-3-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-3-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.3.1"
+
+  arch = "amd64"
+  sha256 "dda41425c7eb06c5e8b3f5ad4904e993aa8a9ab6b61f954ee2e259667cb6ff57"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-3-5.rb
+++ b/Casks/terraform-0-3-5.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-3-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.3.5"
+
+  arch = "amd64"
+  sha256 "d583d58719951a5c3a06eec38390fe31bef7645af7fee3e915293aab7a910885"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-3-6.rb
+++ b/Casks/terraform-0-3-6.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-3-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.3.6"
+
+  arch = "amd64"
+  sha256 "65b4c5bfc34bb0464b691b31ac554132c87ac0c5d7acef936c039777a27dccad"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-3-7.rb
+++ b/Casks/terraform-0-3-7.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-3-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.3.7"
+
+  arch = "amd64"
+  sha256 "aecdc8119cd637e3e60967c97f9912735400814546b8e925152203fb6e99c732"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-4-0.rb
+++ b/Casks/terraform-0-4-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-4-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.4.0"
+
+  arch = "amd64"
+  sha256 "eba9a10b11d572bc5146c1d01353193ba45af2683a0977db09e7b18dff079398"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-4-1.rb
+++ b/Casks/terraform-0-4-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-4-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.4.1"
+
+  arch = "amd64"
+  sha256 "08bb2eaa5b4eae89963e5ed1598689d95d220c0cafb59bbd5f266f8e326ac944"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-4-2.rb
+++ b/Casks/terraform-0-4-2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-4-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.4.2"
+
+  arch = "amd64"
+  sha256 "317e2b9721394c1f6cc6710f13598cd91e8816b82fdc3781485556cadf1311dd"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-5-0.rb
+++ b/Casks/terraform-0-5-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-5-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.5.0"
+
+  arch = "amd64"
+  sha256 "8033564434ed964fc630fe5ff8b4830945d38a528ad5b14e7a88e23f85591f05"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-5-1.rb
+++ b/Casks/terraform-0-5-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-5-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.5.1"
+
+  arch = "amd64"
+  sha256 "5915d7668b07ea3770f1bc8126764f90723eade0245e0634af3b051ae2ceb7e5"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-5-3.rb
+++ b/Casks/terraform-0-5-3.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-5-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.5.3"
+
+  arch = "amd64"
+  sha256 "9d3388266510a03ea5f5ba2a721ab2affc854777c973d821f16e7dcd514adb7b"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-0.rb
+++ b/Casks/terraform-0-6-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.0"
+
+  arch = "amd64"
+  sha256 "c519d3d18d5a2b0605bff6e0ca7bb677ea85c833f8e8dbb4af6a48e0ebf76cad"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-1.rb
+++ b/Casks/terraform-0-6-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.1"
+
+  arch = "amd64"
+  sha256 "a06768862d1c3ee928d26961302c5134c9c8f716e567c4cf52fce85951f61bee"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-10.rb
+++ b/Casks/terraform-0-6-10.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-10" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.10"
+
+  arch = "amd64"
+  sha256 "9009582111ba938bd7e22767f533c712fb763dffa9f390b40b17f18742bfac59"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-11.rb
+++ b/Casks/terraform-0-6-11.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-11" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.11"
+
+  arch = "amd64"
+  sha256 "9802b1d56576bea86e34fd3800e100eb043ab6de5a5fa40f7f05a0a44f364dd2"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-12.rb
+++ b/Casks/terraform-0-6-12.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-12" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.12"
+
+  arch = "amd64"
+  sha256 "eaa50e05a88ef83a9ba18a3768932f4d530ce1b710b29ae29992f94addac0bfb"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-13.rb
+++ b/Casks/terraform-0-6-13.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-13" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.13"
+
+  arch = "amd64"
+  sha256 "5f285ea0bf7f6bd704ef262330f88dc195ffa6ed118490d54961958dfe2dab24"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-14.rb
+++ b/Casks/terraform-0-6-14.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-14" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.14"
+
+  arch = "amd64"
+  sha256 "9334f55a549d5cb3c583430be15e73b407bd7e115dc53db290381a482da17788"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-15.rb
+++ b/Casks/terraform-0-6-15.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-15" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.15"
+
+  arch = "amd64"
+  sha256 "9cb305ac00b85e2575da3c71504f3fdd3f7ef61f35457af999c7b88802143311"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-16.rb
+++ b/Casks/terraform-0-6-16.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-16" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.16"
+
+  arch = "amd64"
+  sha256 "23feb79263126877e6128a03c600cd626f6691a118a474694c5ad45cc5da9366"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-2.rb
+++ b/Casks/terraform-0-6-2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.2"
+
+  arch = "amd64"
+  sha256 "76a11f1ccd4af7881fab07ba7008a05ddf5ddeb25da2683c258619c9223d8162"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-3.rb
+++ b/Casks/terraform-0-6-3.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.3"
+
+  arch = "amd64"
+  sha256 "d5c50b38bdba7dd11ccd31ebe04de9bb4a1f31a8b30ba967c863e3754d1bfd8b"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-4.rb
+++ b/Casks/terraform-0-6-4.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.4"
+
+  arch = "amd64"
+  sha256 "e2eee073432487aabd69003b3a293caa6e087d4b435d29f6406079333e2dca73"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-5.rb
+++ b/Casks/terraform-0-6-5.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.5"
+
+  arch = "amd64"
+  sha256 "ba540f36d1dc3ed9d3db9832db3a2b3f6cfea5d9f80b663281c1d28260d298ed"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-6.rb
+++ b/Casks/terraform-0-6-6.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.6"
+
+  arch = "amd64"
+  sha256 "43912f5d3eac34a73eaa182a78e13e8392ff4b81f053be4a61cd78db53c505a7"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-7.rb
+++ b/Casks/terraform-0-6-7.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.7"
+
+  arch = "amd64"
+  sha256 "fe54fa09af11a1375a2b85912fe416d494a52137be7c5b0b4aaae35d75b0d588"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-8.rb
+++ b/Casks/terraform-0-6-8.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-8" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.8"
+
+  arch = "amd64"
+  sha256 "71fd8ff20f657a4c7d82794756d55c55b0686516a8253356b8edd1a728230577"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-6-9.rb
+++ b/Casks/terraform-0-6-9.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-6-9" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.6.9"
+
+  arch = "amd64"
+  sha256 "9cf892c073a9fce0e9f136162f82c5b2d373c32cc2c5bd5c5eb16631262fad89"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-0.rb
+++ b/Casks/terraform-0-7-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.0"
+
+  arch = "amd64"
+  sha256 "4720e4b2878b3b0d3d781f68ff363707ed42fe39cb89e2e34c6c11f8e0f76b04"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-1.rb
+++ b/Casks/terraform-0-7-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.1"
+
+  arch = "amd64"
+  sha256 "ab5e9ffe690f52ff13b8f095937119d67d3f0a07744be851657555236245dd98"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-10.rb
+++ b/Casks/terraform-0-7-10.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-10" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.10"
+
+  arch = "amd64"
+  sha256 "e65095c09cd94d60f0a6bc470ad29b249051448533344722755cc617bdd277a4"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-11.rb
+++ b/Casks/terraform-0-7-11.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-11" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.11"
+
+  arch = "amd64"
+  sha256 "69c8d2b07f04e9bf0beb4a333dd189d8616d22fe46692bdb5aef10493ac5e5c6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-12.rb
+++ b/Casks/terraform-0-7-12.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-12" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.12"
+
+  arch = "amd64"
+  sha256 "bfd79badf239509b09c5f036bd5cb1d688297644f26ffaf39d89c1abf9a2936d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-13.rb
+++ b/Casks/terraform-0-7-13.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-13" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.13"
+
+  arch = "amd64"
+  sha256 "c1e004ad2bff4e92edb13cf32a18b67b5178fc3597a844beeda09cc4f9c30b65"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-2.rb
+++ b/Casks/terraform-0-7-2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.2"
+
+  arch = "amd64"
+  sha256 "2a441124efd097007414545714927a9239980a5b0707384b0ee07badbae781cf"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-3.rb
+++ b/Casks/terraform-0-7-3.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.3"
+
+  arch = "amd64"
+  sha256 "e0057e4f32e6490361611e3eb34e35f8b5314d861aa26fd9e89e1a7c4ab773bf"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-4.rb
+++ b/Casks/terraform-0-7-4.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.4"
+
+  arch = "amd64"
+  sha256 "21c8ecc161628ecab88f45eba6b5ca1fbf3eb897e8bc951b0fbac4c0ad77fb04"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-5.rb
+++ b/Casks/terraform-0-7-5.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.5"
+
+  arch = "amd64"
+  sha256 "87cae476176b2f4416e5e0eb6c46ff218dd62201c31d3a3dfc16c08849d01b03"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-6.rb
+++ b/Casks/terraform-0-7-6.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.6"
+
+  arch = "amd64"
+  sha256 "5c315498c58700d5e0eeba205c1e07e5299d04dd0f7fb7e87e4c38a8c9903774"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-7.rb
+++ b/Casks/terraform-0-7-7.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.7"
+
+  arch = "amd64"
+  sha256 "eb6255c4c14c61458ea4598a0e3176695c296e9f1650ad56a24a1cb75d8fef35"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-8.rb
+++ b/Casks/terraform-0-7-8.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-8" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.8"
+
+  arch = "amd64"
+  sha256 "9daaec788ee0540d7b3a92f2dcf86656f3c567e2c267c64c03aa712901796470"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-7-9.rb
+++ b/Casks/terraform-0-7-9.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-7-9" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.7.9"
+
+  arch = "amd64"
+  sha256 "960e0e79c9dcaa51fa349f923e62f46fd4b49a91dcb06677ab096918f6074e2e"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-8-0.rb
+++ b/Casks/terraform-0-8-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-8-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.8.0"
+
+  arch = "amd64"
+  sha256 "4f4410be73200f95f84e359409481c8c48bc70e659fc5f7ea3f33a1db574ff65"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-8-1.rb
+++ b/Casks/terraform-0-8-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-8-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.8.1"
+
+  arch = "amd64"
+  sha256 "275104513600bf50a28942131d928d2be405c75f9f36a9c722718500075856a1"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-8-2.rb
+++ b/Casks/terraform-0-8-2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-8-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.8.2"
+
+  arch = "amd64"
+  sha256 "06bec1c06dbeb89ea7fdc2036be972372aa6847d3883786ab285386750a7ceb6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-8-3.rb
+++ b/Casks/terraform-0-8-3.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-8-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.8.3"
+
+  arch = "amd64"
+  sha256 "84ecdd2adf61629a6bd4c1316df8f76290afad689630225d415666b422214a83"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-8-4.rb
+++ b/Casks/terraform-0-8-4.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-8-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.8.4"
+
+  arch = "amd64"
+  sha256 "79e94dfaf439fdbba2a2fe03dd7c90b24efa699b6661155aa9329df43e68ba51"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-8-5.rb
+++ b/Casks/terraform-0-8-5.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-8-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.8.5"
+
+  arch = "amd64"
+  sha256 "10253ac843b7a170844d629cbdbd2287bf687cdd3d2938e4ab9140d10534cf38"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-8-6.rb
+++ b/Casks/terraform-0-8-6.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-8-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.8.6"
+
+  arch = "amd64"
+  sha256 "0b80dedb16ab6583afcf66e9b03d3714fbfa44b827094420956d807b710e4fd6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-8-7.rb
+++ b/Casks/terraform-0-8-7.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-8-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.8.7"
+
+  arch = "amd64"
+  sha256 "ba53c7424bec5db7c01e0a5178ba5e295eb13669fb04fdae41576098baf88b75"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-8-8.rb
+++ b/Casks/terraform-0-8-8.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-8-8" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.8.8"
+
+  arch = "amd64"
+  sha256 "55ab547539e68c9375c144062460457fcfdb3f5b9f412d3bb162f73298602d78"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-9-0.rb
+++ b/Casks/terraform-0-9-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-9-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.9.0"
+
+  arch = "amd64"
+  sha256 "b6de7307c989455c4b1f351c2df1ad1a0308edc71868bb432ad74f3980f8a6a3"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-9-1.rb
+++ b/Casks/terraform-0-9-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-9-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.9.1"
+
+  arch = "amd64"
+  sha256 "4140c52917da91a276db34f01e5efc27d07b6e1deeede4137625fccf7bfabb83"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-9-10.rb
+++ b/Casks/terraform-0-9-10.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-9-10" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.9.10"
+
+  arch = "amd64"
+  sha256 "8d55db3e114a72ec2cefb2e928af485c10f61c2df8121847972f73ca301fe5c6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-9-11.rb
+++ b/Casks/terraform-0-9-11.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-9-11" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.9.11"
+
+  arch = "amd64"
+  sha256 "31ca22b9b8e840789314085ea3a9a666af261b17c0f86b68dfedf1eb50345cbd"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-9-2.rb
+++ b/Casks/terraform-0-9-2.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-9-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.9.2"
+
+  arch = "amd64"
+  sha256 "33d9bbe1516a4085998c74d5a265aa0354d29a11eb56a21611dbcc806aec9c6f"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-9-3.rb
+++ b/Casks/terraform-0-9-3.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-9-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.9.3"
+
+  arch = "amd64"
+  sha256 "180afdeb14f4049f3374fe02b9143ad428ebd31dd89c6595775d7ba439d7fbf0"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-9-4.rb
+++ b/Casks/terraform-0-9-4.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-9-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.9.4"
+
+  arch = "amd64"
+  sha256 "73ec3c66a77e0c0879e6397fe2b4c4910b24464971fd0c27795b0fa09143f9ad"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-9-5.rb
+++ b/Casks/terraform-0-9-5.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-9-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.9.5"
+
+  arch = "amd64"
+  sha256 "83b5596c2a510925f90a6572d237b864bc4cf277609ebac294c8f400261e657c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-9-6.rb
+++ b/Casks/terraform-0-9-6.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-9-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.9.6"
+
+  arch = "amd64"
+  sha256 "71f53879c2fc33af57238cdb67a344d576ae3ae88f8db112122d433bd762788d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-9-7.rb
+++ b/Casks/terraform-0-9-7.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-9-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.9.7"
+
+  arch = "amd64"
+  sha256 "ece7ad727eac202b571c64018ec3d09b4d7693aea7033db81e239d96d11d48b9"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-9-8.rb
+++ b/Casks/terraform-0-9-8.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-9-8" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.9.8"
+
+  arch = "amd64"
+  sha256 "f2f4e12bcb6e8bbd8876194221fbb79860ad700926d47a42654a354d70b06022"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-0-9-9.rb
+++ b/Casks/terraform-0-9-9.rb
@@ -1,0 +1,17 @@
+cask "terraform-0-9-9" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "0.9.9"
+
+  arch = "amd64"
+  sha256 "657d522fc08b6f6fba0c913c9d474a80b1c9c1c6e9a497445455a8ff22fd72b3"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-0-0.rb
+++ b/Casks/terraform-1-0-0.rb
@@ -1,0 +1,17 @@
+cask "terraform-1-0-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.0.0"
+
+  arch = "amd64"
+  sha256 "397eccdf68eb343e4946c37a877a4764409fe0b9037041daf1d17db18bca9839"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-0-1.rb
+++ b/Casks/terraform-1-0-1.rb
@@ -1,0 +1,17 @@
+cask "terraform-1-0-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.0.1"
+
+  arch = "amd64"
+  sha256 "260524ebe620a73df4c9732fec6887e74414df6d3210f5c6eaca24558f320938"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-0-10.rb
+++ b/Casks/terraform-1-0-10.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-0-10" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.0.10"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "077479e98701bc9be88db21abeec684286fd85a3463ce437d7739d2a4e372f18",
+    arm: "776f2e144039ece66ae326ebda0884254848a2e11f0590757d02e3a74f058c81"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-0-11.rb
+++ b/Casks/terraform-1-0-11.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-0-11" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.0.11"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "551a16b612edaae1037925d0e2dba30d16504ff4bd66606955172c2ed8d76131",
+    arm: "737e1765afbadb3d76e1929d4b4af8da55010839aa08e9e730d46791eb8ea5a6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-0-2.rb
+++ b/Casks/terraform-1-0-2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-0-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.0.2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "f323afd5804bf6dbe639585bea5edc68f429011fc8a44519f3f1654ab88e9a5f",
+    arm: "f653da49e48dfd677403ba6babede93918ab4196280c0ea4d64a442d948723b6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-0-3.rb
+++ b/Casks/terraform-1-0-3.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-0-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.0.3"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "6e86dfff2f90ddc1232b38487613d5f7eab69f227d76c4337921517aaaa11c4f",
+    arm: "a16f8851e11fcc5b922c529169918b05d39ffd85557e6bbbcd7843cf07e47910"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-0-4.rb
+++ b/Casks/terraform-1-0-4.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-0-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.0.4"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "0d2083b1a812572eef068dbfd60ffbfa10f843434bec5f7e82c5f7a778761fa1",
+    arm: "8942347acdf0e5499366c6ee4fc1da7a4b4c24f9d80113a12e8b72619786b7eb"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-0-5.rb
+++ b/Casks/terraform-1-0-5.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-0-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.0.5"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "51b481f2cc02651c14854f57dc0c43c3918b19b6fc5e687295b98beee5d20271",
+    arm: "8fadd8bbcdcaf6452d9937af6b916572f481caabcc29ea9aac61c7f4759e133e"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-0-6.rb
+++ b/Casks/terraform-1-0-6.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-0-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.0.6"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "5ac4f41d5e28f31817927f2c5766c5d9b98b68d7b342e25b22d053f9ecd5a9f1",
+    arm: "613020f90a6a5d0b98ebeb4e7cdc4b392aa06ce738fbb700159a465cd27dcbfa"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-0-7.rb
+++ b/Casks/terraform-1-0-7.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-0-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.0.7"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "23b85d914465882b027d3819cc05cd114a1aaf39b550de742e81a99daa998183",
+    arm: "d9062959f28ba0f934bfe2b6e0b021e0c01a48fa065102554ca103b8274e8e0c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-0-8.rb
+++ b/Casks/terraform-1-0-8.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-0-8" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.0.8"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "909781ee76250cf7445f3b7d2b82c701688725fa1db3fb5543dfeed8c47b59de",
+    arm: "92fa31b93d736fab6f3d105beb502a9da908445ed942a3d46952eae88907c53e"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-0-9.rb
+++ b/Casks/terraform-1-0-9.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-0-9" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.0.9"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "be122ff7fb925643c5ebf4e5704b18426e18d3ca49ab59ae33d208c908cb6d5a",
+    arm: "89b2b4fd1a0c57fabc08ad3180ad148b1f7c1c0492ed865408f75f12e11a083b"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-alpha20210616.rb
+++ b/Casks/terraform-1-1-0-alpha20210616.rb
@@ -1,0 +1,17 @@
+cask "terraform-1-1-0-alpha20210616" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-alpha20210616"
+
+  arch = "amd64"
+  sha256 "fd9a9c6ae65f3678b81e4ba5fe72350f0191ed0a0fc2ec12a6139e3a8887e203"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-alpha20210630.rb
+++ b/Casks/terraform-1-1-0-alpha20210630.rb
@@ -1,0 +1,17 @@
+cask "terraform-1-1-0-alpha20210630" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-alpha20210630"
+
+  arch = "amd64"
+  sha256 "bd8d4a966661875b5c38e7d77a5aabcabb1bd98630c014a4626cbc4b2f8b8f9e"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-alpha20210714.rb
+++ b/Casks/terraform-1-1-0-alpha20210714.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-0-alpha20210714" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-alpha20210714"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "a848f98f2eaa2ef6816d558bf63badccfa16872520ad663ccdc37477dcdefb2c",
+    arm: "1eda0c53c37ae48714168552a1ed90636b7838da38d39e33a27ca87fa23cda33"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-alpha20210728.rb
+++ b/Casks/terraform-1-1-0-alpha20210728.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-0-alpha20210728" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-alpha20210728"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "9b63d9bab48bc9dfc3cb719fb8869746f7d16626888c2895c18e000fcf80cacd",
+    arm: "b0c793e019ba8e43c9d0d9287463b5ddd8c09afcb06863f0270334c7ae3e74b2"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-alpha20210811.rb
+++ b/Casks/terraform-1-1-0-alpha20210811.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-0-alpha20210811" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-alpha20210811"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "bd9afe8033bda2b04e18d97d5bd0f77a9cd80747e9ff8aff4ab83263fd81d76c",
+    arm: "22628eca35df6019891929f49466f2512bc0032c10014076c2b2e5637be6f8e4"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-alpha20210908.rb
+++ b/Casks/terraform-1-1-0-alpha20210908.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-0-alpha20210908" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-alpha20210908"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "e23c5f21b4d9cda9f2965a4cc38109e26e0decb77b11e378c4e526a35ab66ff6",
+    arm: "5830f3197ccd3485fc59d808bfc90e852b4f1246e1b39dd0c5250e118943ecc5"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-alpha20210922.rb
+++ b/Casks/terraform-1-1-0-alpha20210922.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-0-alpha20210922" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-alpha20210922"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "79fb74af2ca42e39f217db4ca8cadd4a47ae900f632ec947b24738c65b80e40a",
+    arm: "d84fd0d2e967d2a822cf86c937739672ae533169af4b36cd8c6880f81847406b"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-alpha20211006.rb
+++ b/Casks/terraform-1-1-0-alpha20211006.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-0-alpha20211006" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-alpha20211006"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "11eddb6bd353f801e0e0b38d29859e31897eac404285d60424611d6fa2ddda33",
+    arm: "fff8eceebfef30eeb52ca153033f69d7dd0925951deb42b016ad84c04aa7f643"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-alpha20211020.rb
+++ b/Casks/terraform-1-1-0-alpha20211020.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-0-alpha20211020" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-alpha20211020"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "c7141fa2ad25a856155284c79b295e2054f417a3bfca88508419dba058294e10",
+    arm: "0302cb342a1f32d821929f130637af1b44dfd1732323c8bbed8a007d90a3396c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-alpha20211029.rb
+++ b/Casks/terraform-1-1-0-alpha20211029.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-0-alpha20211029" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-alpha20211029"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "de70d87ea634290ac03ee20c5901eb5cef68d42d1c5f74a001863f7479805646",
+    arm: "3631eec8ec544e56092f29e0e8c0466f86a94e92d5708823bcf36a189eaa0b74"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-beta1.rb
+++ b/Casks/terraform-1-1-0-beta1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-beta1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "9eecd065f592541b0aa444830e905606e549c92969526ff6a6b5d3d9059268a4",
+    arm: "c55dbc74a318761f13b8343a116b75a1720aa8153e409aca0ce4519debfafd55"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-beta2.rb
+++ b/Casks/terraform-1-1-0-beta2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-0-beta2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-beta2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "ccdcab84417c3643ab1f97fb97b6220ca9a27b8341746799130d8d4c55e65c6f",
+    arm: "8b9f02ba2e197ee439caa7150de13d293ce7b13156ad3ae296d1267b0ea422d7"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0-rc1.rb
+++ b/Casks/terraform-1-1-0-rc1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0-rc1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "a6d28534ff87971f236173a231065ccbbd3565b7fe2ca4f750873c51db8a4fb0",
+    arm: "3b005902d98f38aab052b233f15dab0048efba6b3a635ee255ce801df5e8aa97"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-0.rb
+++ b/Casks/terraform-1-1-0.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.0"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "6e0ba9afb8795a544e70dc0459f0095fea7df15e38f5d88a7dd3f620d50f8bfe",
+    arm: "7955e173c7eadb87123fc0633c3ee67d5ba3b7d6c7f485fe803efed9f99dce54"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-1.rb
+++ b/Casks/terraform-1-1-1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "d125dd2e92b9245f2202199b52f234035f36bdcbcd9a06f08e647e14a9d9067a",
+    arm: "4cb6e5eb4f6036924caf934c509a1dfd61cd2c651bb3ee8fbfe2e2914dd9ed17"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-2.rb
+++ b/Casks/terraform-1-1-2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "78faa76db5dc0ecfe4bf7c6368dbf5cca019a806f9d203580a24a4e0f8cd8353",
+    arm: "cc3bd03b72db6247c9105edfeb9c8f674cf603e08259075143ffad66f5c25a07"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-3.rb
+++ b/Casks/terraform-1-1-3.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.3"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "016bab760c96d4e64d2140a5f25c614ccc13c3fe9b3889e70c564bd02099259f",
+    arm: "02ba769bb0a8d4bc50ff60989b0f201ce54fd2afac2fb3544a0791aca5d3f6d5"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-4.rb
+++ b/Casks/terraform-1-1-4.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.4"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "4f3bc78fedd4aa17f67acc0db4eafdb6d70ba72392aaba65fe72855520f11f3d",
+    arm: "5642b46e9c7fb692f05eba998cd4065fb2e48aa8b0aac9d2a116472fbabe34a1"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-5.rb
+++ b/Casks/terraform-1-1-5.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.5"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "dcf7133ebf61d195e432ddcb70e604bf45056163d960e991881efbecdbd7892b",
+    arm: "6e5a8d22343722dc8bfcf1d2fd7b742f5b46287f87171e8143fc9b87db32c3d4"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-6.rb
+++ b/Casks/terraform-1-1-6.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.6"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "7a499c1f08d89548ae4c0e829eea43845fa1bd7b464e7df46102b35e6081fe44",
+    arm: "f06a14fdb610ec5a7f18bdbb2f67187230eb418329756732d970b6ca3dae12c3"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-7.rb
+++ b/Casks/terraform-1-1-7.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.7"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "6e56eea328683541f6de0d5f449251a974d173e6d8161530956a20d9c239731a",
+    arm: "8919ceee34f6bfb16a6e9ff61c95f4043c35c6d70b21de27e5a153c19c7eba9c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-8.rb
+++ b/Casks/terraform-1-1-8.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-8" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.8"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "48f1f1e04d0aa8f5f1a661de95e3c2b8fd8ab16b3d44015372aff7693d36c2cf",
+    arm: "943e1948c4eae82cf8b490bb274939fe666252bbc146f098e7da65b23416264a"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-1-9.rb
+++ b/Casks/terraform-1-1-9.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-1-9" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.1.9"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "685258b525eae94fb0b406faf661aa056d31666256bf28e625365a251cb89fdc",
+    arm: "39fac4be74462be86b2290dd09fe1092f73dfb48e2df92406af0e199cfa6a16c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-0-alpha-20220328.rb
+++ b/Casks/terraform-1-2-0-alpha-20220328.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-0-alpha-20220328" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.0-alpha-20220328"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "6d7252fd9a2b43b27a217d0ff7bf38b1308b0cd6104918a308655332a789f8b9",
+    arm: "5645246a227c922b2f82eb79ca23be8d2db901f1bcb5527373203c56637d4741"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-0-alpha20220413.rb
+++ b/Casks/terraform-1-2-0-alpha20220413.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-0-alpha20220413" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.0-alpha20220413"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "70fd32df5851a9a5d132119e0328708a4643109402813301fc2254fb6a7dd210",
+    arm: "1d4dbcc179c20d44a8fa7c0fec2f93078ccce94ad642bb1204041af2a0e53c76"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-0-beta1.rb
+++ b/Casks/terraform-1-2-0-beta1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.0-beta1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "da218c513f6062f565ca5f1749acca6cf93d80047d618c2d52b1ee31b3243d64",
+    arm: "6dd843ee5e947ca93d731bccf147753c43dfcdfd7f5df1460e932822b5340bd3"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-0-rc1.rb
+++ b/Casks/terraform-1-2-0-rc1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.0-rc1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "6891ce78a1b184484ea297d7ed7b82367b23191ff03bcf029d9f32209a18e7df",
+    arm: "459b92dac3965a3888cae2d11930785b1e7c76189fd2e8d3feb1a0bbebb34ce0"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-0-rc2.rb
+++ b/Casks/terraform-1-2-0-rc2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-0-rc2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.0-rc2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "74cbeb5ef960093dd3a37ddfed1af5c7659d54940a0d977c041f44dd616711a3",
+    arm: "f60029b6e08c5793c19268b44305d3ced89243b40b257bfa7e56c6feb443bed9"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-0.rb
+++ b/Casks/terraform-1-2-0.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.0"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "1b102ba3bf0c60ff6cbee74f721bf8105793c1107a1c6d03dcab98d7079f0c77",
+    arm: "f5e46cabe5889b60597f0e9c365cbc663e4c952c90a16c10489897c2075ae4f0"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-1.rb
+++ b/Casks/terraform-1-2-1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "31c0fd4deb7c6a77c08d2fdf59c37950e6df7165088c004e1dd7f5e09fbf6307",
+    arm: "70159b3e3eb49ee71193815943d9217c59203fd4ee8c6960aeded744094a2250"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-2.rb
+++ b/Casks/terraform-1-2-2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "1d22663c1ab22ecea774ae63aee21eecfee0bbc23b953206d889a5ba3c08525a",
+    arm: "b87716b55a3b10cced60db5285bae57aee9cc0f81c555dccdc4f54f62c2a3b60"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-3.rb
+++ b/Casks/terraform-1-2-3.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.3"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "bdc22658463237530dc120dadb0221762d9fb9116e7a6e0dc063d8ae649c431e",
+    arm: "6f06debac2ac54951464bf490e1606f973ab53ad8ba5decea76646e8f9309512"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-4.rb
+++ b/Casks/terraform-1-2-4.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.4"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "e7d2c66264a3da94854ae6ff692bbb9a1bc11c36bb5658e3ef19841388a07430",
+    arm: "c31754ff5553707ef9fd2f913b833c779ab05ce192eb14913f51816a077c6798"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-5.rb
+++ b/Casks/terraform-1-2-5.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.5"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "2520fde736b43332b0c2648f4f6dde407335f322a3085114dc4f70e6e50eadc0",
+    arm: "92ad40db4a0930bdf872d6336a7b3a18b17c6fd04d9fc769b554bf51c8add505"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-6.rb
+++ b/Casks/terraform-1-2-6.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.6"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "d896d2776af8b06cd4acd695ad75913040ce31234f5948688fd3c3fde53b1f75",
+    arm: "c88ceb34f343a2bb86960e32925c5ec43b41922ee9ede1019c5cf7d7b4097718"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-7.rb
+++ b/Casks/terraform-1-2-7.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.7"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "74e47b54ea78685be24c84e0e17b22b56220afcdb24ec853514b3863199f01e4",
+    arm: "ec4e623914b411f8cc93a1e71396a1e7f1fe1e96bb2e532ba3e955d2ca5cc442"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-8.rb
+++ b/Casks/terraform-1-2-8.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-8" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.8"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "efd3e21a9bb1cfa68303f8d119ea8970dbb616f5f99caa0fe21d796e0cd70252",
+    arm: "2c83bfea9e1c202c449e91bee06a804afb45cb8ba64a73da48fb0f61df51b327"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-2-9.rb
+++ b/Casks/terraform-1-2-9.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-2-9" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.2.9"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "84a678ece9929cebc34c7a9a1ba287c8b91820b336f4af8437af7feaa0117b7c",
+    arm: "bc3b94b53cdf1be3c4988faa61aad343f48e013928c64bfc6ebeb61657f97baa"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-0-alpha20220608.rb
+++ b/Casks/terraform-1-3-0-alpha20220608.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-0-alpha20220608" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.0-alpha20220608"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "5917598e8fadf9d77e0201c0327e33a6123d6448530724417f4371a25944ed99",
+    arm: "1662a8e2b86c920c39ccf298bce464f7d85b05f16670b06fd370698f849d7f60"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-0-alpha20220622.rb
+++ b/Casks/terraform-1-3-0-alpha20220622.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-0-alpha20220622" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.0-alpha20220622"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "2b6b1fcff71c20c408e1b3cbee8236645898e24e64006e6c999cb2ec9a6f610c",
+    arm: "757eee385bd67ca1878ffd51e2e61c156027ea371510bd10aea3d8f532b27983"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-0-alpha20220706.rb
+++ b/Casks/terraform-1-3-0-alpha20220706.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-0-alpha20220706" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.0-alpha20220706"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "22260dc6eb0cd8a18f690b80299bf07dc5944876bbf6ec552837c4242303cb62",
+    arm: "b7eb881cf519383ac220b65207f90349bbff6064a037905a02855f5d8fcf7cec"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-0-alpha20220803.rb
+++ b/Casks/terraform-1-3-0-alpha20220803.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-0-alpha20220803" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.0-alpha20220803"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "dff45b9ebc241b7928a7f47c3eed0a2e2131f79de20e03ff4f258ee5c6c8dec1",
+    arm: "dbbc1eb035fd144dc12e4c95549506473f550b696404ec374c912bd8f36d3930"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-0-alpha20220817.rb
+++ b/Casks/terraform-1-3-0-alpha20220817.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-0-alpha20220817" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.0-alpha20220817"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "78514bf223734e6d0c10697df509c63eb8327651b8746eeb1607a6b13cb6ec95",
+    arm: "c463904ab2e53dfe9487dd3aa429de32ec300ea7a643b600759ed432d77f1713"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-0-beta1.rb
+++ b/Casks/terraform-1-3-0-beta1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.0-beta1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "3d07988b32e8a4d744765d0c78ebc64e43f737621d19cf05ef898f8537a12ae4",
+    arm: "01efcf84b1d98c20e3675b76221f67b4f0d789f450ded6893bf09092640ebfd0"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-0-rc1.rb
+++ b/Casks/terraform-1-3-0-rc1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.0-rc1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "7010d88700f8b64c647495f8909a46578f70c92178a9e0b710619c1dc825e9f8",
+    arm: "9bb099ead7093701e55e23016cc476188ef19f538b16a69dacc2aeeb4382db30"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-0.rb
+++ b/Casks/terraform-1-3-0.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.0"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "80e55182d4495da867c93c25dc6ae29be83ece39d3225e6adedecd55b72d6bbf",
+    arm: "df703317b5c7f80dc7c61e46de4697c9f440e650a893623351ab5e184995b404"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-1.rb
+++ b/Casks/terraform-1-3-1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "4282ebe6d1d72ace0d93e8a4bcf9a6f3aceac107966216355bb516b1c49cc203",
+    arm: "f0514f29b08da2f39ba4fff0d7eb40093915c9c69ddc700b6f39b78275207d96"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-10.rb
+++ b/Casks/terraform-1-3-10.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-10" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.10"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "e5cf68ef9b259503abf515a1716fcfe21d46af22e24b8ebbbe7849fbfafb428c",
+    arm: "39cf7882108034f78c0d9144153271efb11ba99924170828eda9b0196f3da6fd"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-2.rb
+++ b/Casks/terraform-1-3-2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "3639461bbc712dc130913bbe632afb449fce8c0df692429d311e7cb808601901",
+    arm: "80480acbfee2e2d0b094f721f7568a40b790603080d6612e19b797a16b8ba82d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-3.rb
+++ b/Casks/terraform-1-3-3.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.3"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "2b3cf653cd106becdea562b6c8d3f8939641e5626c5278729cbef81678fa9f42",
+    arm: "51e94ecf88059e8a53c363a048b658230f560574f99b0d8396ebacead894d159"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-4.rb
+++ b/Casks/terraform-1-3-4.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.4"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "2a75c69ec5ed8506658b266a40075256b62a7d245ff6297df7e48fa72af23879",
+    arm: "a1f740f92afac6db84421a3ec07d9061c34a32f88b4b0b47d243de16c961169f"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-5.rb
+++ b/Casks/terraform-1-3-5.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.5"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "e6c9836188265b20c2588e9c9d6b1727094b324a379337e68ba58a6d26be8b51",
+    arm: "fcec1cbff229fbe59b03257ba2451d5ad1f5129714f08ccf6372b2737647c063"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-6.rb
+++ b/Casks/terraform-1-3-6.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.6"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "13881fe0100238577394243a90c0631783aad21b77a9a7ee830404f86c0d37bb",
+    arm: "dbff0aeeaeee877c254f5414bef5c9d186e159aa0019223aac678abad9442c53"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-7.rb
+++ b/Casks/terraform-1-3-7.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.7"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "eeae48adcd55212b34148ed203dd5843e9b2a84a852a9877f3386fadb0514980",
+    arm: "01d553db5f7b4cf0729b725e4402643efde5884b1dabf5eb80af328ce5e447cf"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-8.rb
+++ b/Casks/terraform-1-3-8.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-8" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.8"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "1a27a6fac31ecb05de610daf61a29fe83d304d7c519d773afbf56c11c3b6276b",
+    arm: "873b05ac81645cd7289d6ccfd3e73d4735af1a453f2cd19da0650bdabf7d2eb6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-3-9.rb
+++ b/Casks/terraform-1-3-9.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-3-9" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.3.9"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "a73326ea8fb06f6976597e005f8047cbd55ac76ed1e517303d8f6395db6c7805",
+    arm: "d8a59a794a7f99b484a07a0ed2aa6520921d146ac5a7f4b1b806dcf5c4af0525"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-0-alpha20221109.rb
+++ b/Casks/terraform-1-4-0-alpha20221109.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-0-alpha20221109" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.0-alpha20221109"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "3c34e6b6f2afd4847bf6bc76f3dc5630df655d0469a699f3cdf4d0ee11c7505f",
+    arm: "4537eb0228b27abb1bc1935e0ced1bb735b57d4e76a2f7d2ab243fe62fafd8c0"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-0-alpha20221207.rb
+++ b/Casks/terraform-1-4-0-alpha20221207.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-0-alpha20221207" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.0-alpha20221207"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "26c96a6ce8a199c3cce28c4da073c2d3349d48f3cdead3804a472bdeb6a31e5f",
+    arm: "9d222e60826e30ce72be4f1768573f279eeac3dba571f896bf737cafaae6e6be"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-0-beta1.rb
+++ b/Casks/terraform-1-4-0-beta1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.0-beta1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "08c54d8aa2429dfc289e2de06797d3f0f3b03e234e90a8e3c64bc69aa2f5f5c5",
+    arm: "62de2c92d349626ecde3bbbb8645ac61247b6860f83d34a0ac5e93696ccc3813"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-0-beta2.rb
+++ b/Casks/terraform-1-4-0-beta2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-0-beta2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.0-beta2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "94b42aabedb8b57fa022d7d4720ed45dc67cb86c91e3dc182eb2aef70bb33408",
+    arm: "917bbbf62657640f3196125b232cc5503b5dcfbba23001ade03164ef4a4f9ea0"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-0-rc1.rb
+++ b/Casks/terraform-1-4-0-rc1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.0-rc1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "db875cd9b42a4ea285a9365a329e42de3affba53cdcbd96f86588546c6b06fff",
+    arm: "46ac4bd57da743c70dac00bd3dccfa25fcbf7cfaa520b4c1cd504d669776d107"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-0.rb
+++ b/Casks/terraform-1-4-0.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.0"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "e897a4217f1c3bfe37c694570dcc6371336fbda698790bb6b0547ec8daf1ffb3",
+    arm: "d4a1e564714c6acf848e86dc020ff182477b49f932e3f550a5d9c8f5da7636fb"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-1.rb
+++ b/Casks/terraform-1-4-1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "96466364a7e66e3d456ecb6c85a63c83e124c004f8835fb8ea9b7bbb7542a9d0",
+    arm: "61f76e130b97c8a9017d8aaff15d252af29117e35ea1a0fc30bcaab7ceafce73"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-2.rb
+++ b/Casks/terraform-1-4-2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "c218a6c0ef6692b25af16995c8c7bdf6739e9638fef9235c6aced3cd84afaf66",
+    arm: "af8ff7576c8fc41496fdf97e9199b00d8d81729a6a0e821eaf4dfd08aa763540"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-3.rb
+++ b/Casks/terraform-1-4-3.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.3"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "89bdb242bfacf24167f365ef7a3bf0ad0e443ddd27ebde425fb71d77ce1a2597",
+    arm: "20b9d484bf99ada6c0de89316176ba33f7c87f64c0738991188465147bba221b"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-4.rb
+++ b/Casks/terraform-1-4-4.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.4"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "0303ed9d7e5a225fc2e6fa9bf76fc6574c0c0359f22d5dfc04bc8b3234444f7c",
+    arm: "75602d9ec491982ceabea813569579b2991093a4e0d76b7ca86ffd9b7a2a1d1e"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-5.rb
+++ b/Casks/terraform-1-4-5.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.5"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "808e54d826737e9a0ca79bbe29330e50d3622bbeeb26066c63b371a291731711",
+    arm: "7104d9d13632aa61b494a349c589048d21bd550e579404c3a41c4932e4d6aa97"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-6.rb
+++ b/Casks/terraform-1-4-6.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.6"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "5d8332994b86411b049391d31ad1a0785dfb470db8b9c50617de28ddb5d1f25d",
+    arm: "30a2f87298ff9f299452119bd14afaa8d5b000c572f62fa64baf432e35d9dec1"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-4-7.rb
+++ b/Casks/terraform-1-4-7.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-4-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.4.7"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "603764c07862bd3a87fce193f8b9823383df22626b254f353c83511635763301",
+    arm: "4b2ae04467469b923d038e6720ae1f92cb2adaa96b7ab08199c2fffee8b45baa"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-0-alpha20230405.rb
+++ b/Casks/terraform-1-5-0-alpha20230405.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-0-alpha20230405" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.0-alpha20230405"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "67710a24862066a607f18aa9b8bad3c810b31fadbd3b4999395894f527a89f5d",
+    arm: "b5e175ff971d6e58854dfc6a2388847372ba58f9b2abecf8ba1108be28181e63"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-0-alpha20230504.rb
+++ b/Casks/terraform-1-5-0-alpha20230504.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-0-alpha20230504" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.0-alpha20230504"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "32c5f4b9ff4258160fb94bcc5f04c9f187ebf1f56cf1ca6efc5e11c0aca500b6",
+    arm: "d8940671bdf5dc2124eff2dbaa1a82e0e3847a38c7501e52d6b9c6f908002efd"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-0-beta1.rb
+++ b/Casks/terraform-1-5-0-beta1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.0-beta1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "e4485902a7086afb80b35626326274a041cc38b2e57fdd1f995d5747e1e50f99",
+    arm: "7d5364ccccd2faac8f9bbcfea056515028c5b3d7cc1430f465e3cc786db92182"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-0-beta2.rb
+++ b/Casks/terraform-1-5-0-beta2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-0-beta2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.0-beta2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "d34cddf4636872d9e8fd840b5e421bec42552323165ef0589eeb8dc4bd442c48",
+    arm: "b7be82184bbe91d2f042151f7f097522cfb3c990cb18982caa1591305f619a0b"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-0-rc1.rb
+++ b/Casks/terraform-1-5-0-rc1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.0-rc1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "f99eddbdf9c003b5ba24293d2c7e1c283005e352f56c2242ed2dec5e90fa4466",
+    arm: "0974e0e234563004187fe1c83433d55103a00d4070ed1acb8558a79e82428aea"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-0-rc2.rb
+++ b/Casks/terraform-1-5-0-rc2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-0-rc2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.0-rc2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "9893f178ecb84d019ff4c3ceb2d6570f019e8aa811ed9d5b1526f58efed07d93",
+    arm: "35310803e55d604885d5a33a7f5cc914a3ae2ad183479bebcf1a699180538db5"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-0.rb
+++ b/Casks/terraform-1-5-0.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.0"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "dd64d8a2a75519b933b4f1d76417675ea66bdb45c2a2672cf511825091eba789",
+    arm: "0765371227ab09e1bb64d606fcfe3d157a2992ac3b82ffabfb9976db53bd791e"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-1.rb
+++ b/Casks/terraform-1-5-1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "4f9f518b40399a9271dd8e449a6335ec94a4de60fc8789711ede7a4b9e630a47",
+    arm: "f691b79319bd82daac2d8b6cbb595d3e8523296c4cd20bf7da0d12fe9eefdfa7"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-2.rb
+++ b/Casks/terraform-1-5-2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "0484b5c7d5daa17cfff476f29b027398d805c00a8c276f884734b4c6fadd15ec",
+    arm: "75c5632f221adbba38d569bdaeb6c3cb90b7f82e26b01e39b3b7e1c16bb0e4d4"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-3.rb
+++ b/Casks/terraform-1-5-3.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.3"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "a5ecd11c8ed9b6c5182a84bce9c3c9c092f86916cf117bca855991853502af94",
+    arm: "444e5565806041d9899a9ba50549840eaa2a2cb7d5b59bb08c5874f92bc4963d"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-4.rb
+++ b/Casks/terraform-1-5-4.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.4"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "27aca7551143d98be83b780fa0040b359c43a6704bdd49514ea582d942752718",
+    arm: "6d68b0e1c0eab5f525f395ddaee360e2eccddff49c2af37d132e8c045b5001c5"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-5.rb
+++ b/Casks/terraform-1-5-5.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.5"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "6d61639e2141b7c23a9219c63994f729aa41f91110a1aa08b8a37969fb45e229",
+    arm: "c7fdeddb4739fdd5bada9d45fd786e2cbaf6e9e364693eee45c83e95281dad3a"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-6.rb
+++ b/Casks/terraform-1-5-6.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.6"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "a65a994111b9d1c7fca8fdb76470430a54e1367c6342507228954d944e82f9db",
+    arm: "c540d0ccbfb37884232dffd277c0ed08ab01ea7c05fe61b66951dddfc0dd802c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-5-7.rb
+++ b/Casks/terraform-1-5-7.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-5-7" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.5.7"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "b310ec0e626e9799000cfc8e30247cd827cf7f8030c8e0400257c7f111e93537",
+    arm: "db7c33eb1a446b73a443e2c55b532845f7b70cd56100bec4c96f15cfab5f50cb"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-0-alpha20230719.rb
+++ b/Casks/terraform-1-6-0-alpha20230719.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-0-alpha20230719" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.0-alpha20230719"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "16dc5e01e61f75500e67a33ebfe42734857c58d4edbd5c88c2b378bbc2faabf3",
+    arm: "a167b313daaa04f68af97690113d051452eb3559550c1342b5a53a4726837a7e"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-0-alpha20230802.rb
+++ b/Casks/terraform-1-6-0-alpha20230802.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-0-alpha20230802" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.0-alpha20230802"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "f58e5cecc9a65539952efb49df0002084265b261cb68eb0186e38e4676a9bb23",
+    arm: "11d07e1e4295f1b42c4ee75c198bd2c9c18842ff4132a907ecf9591bf80a0b04"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-0-alpha20230816.rb
+++ b/Casks/terraform-1-6-0-alpha20230816.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-0-alpha20230816" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.0-alpha20230816"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "265dc14d93397f0225fcc653dffef229eb31efe5529eae38cc7a4421da3b81f0",
+    arm: "e8df6d86281175708a09ae80aaa82ff7845fc930b368b23d7630f0a45b696511"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-0-beta1.rb
+++ b/Casks/terraform-1-6-0-beta1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.0-beta1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "7ee964e69df8dc77d213a7a1ffa94de1264f47f72931d3711fc0b75a3d3f285c",
+    arm: "a6d3116887e69e00a277d7fdeff3705d7d308703798aa7d8d9e9249dac165eab"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-0-beta2.rb
+++ b/Casks/terraform-1-6-0-beta2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-0-beta2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.0-beta2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "11271e7866bac900eebf25e585d4b6430deb3642d8f714009efcccfb36f5402a",
+    arm: "cacd0afbc7939f337fe20548f37d6553566e64a125724a0984d255af6d2a5225"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-0-beta3.rb
+++ b/Casks/terraform-1-6-0-beta3.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-0-beta3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.0-beta3"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "b2cb44e473d196b4e7d9014e1f12acc140e10ea93e14c55da10a82a8af19f21f",
+    arm: "ddbdf706f205e5def3388e630786f5f17d72ac15ac5e3d7521fa95a4d4f6d76c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-0-rc1.rb
+++ b/Casks/terraform-1-6-0-rc1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.0-rc1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "e5b33535abd89965cffedf07aa74a938228f10e4521f773cc3263ccb941df3ed",
+    arm: "a0cc13513b61cf7a0034dc25596770fa9d69c9b79e488ac8f2e659b46b5f6ff3"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-0.rb
+++ b/Casks/terraform-1-6-0.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.0"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "8993da0dac34cc8ba9b88f925c17d54ec490bea6d18f6f49b07d535e6264a608",
+    arm: "aaf3f6639c9fd3864059955a36ccdadd7b54bab681fbe760525548a53cc0c7ec"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-1.rb
+++ b/Casks/terraform-1-6-1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "48951cc7f15bc028a867642425db720c18f13491007ee218dcc54b5ea0519d17",
+    arm: "85ad9903a48c1b997540d1b9fdd47d7b29cb6be740e7c34f6f8afc7581f4ac8e"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-2.rb
+++ b/Casks/terraform-1-6-2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "361ffd98f0cdee631cb1475688471c5fb8f41bd6a4d8d300f29df384c82d6316",
+    arm: "87345e9f2932c29c8d00c5ca9e0361fada18accc2573fd66883b3adb40949be8"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-3.rb
+++ b/Casks/terraform-1-6-3.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.3"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "6fbd1ba3d64daad05d9384568f7300ee9f15e18a5f3a19a33fe48b8d1b44385a",
+    arm: "8cad19d5f34c6ab2af21219fc3968ba30084f5e39bf219230706d360869ed8e9"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-4.rb
+++ b/Casks/terraform-1-6-4.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.4"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "0a93865c56fac0cec9faa739fa81bf69fe58614e9e8d74c088b6c414055b5453",
+    arm: "c3c6196b71946c7825d1e9a1d7d03be1c68b07fd4528a7bbf918f718c4164ffa"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-5.rb
+++ b/Casks/terraform-1-6-5.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.5"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "6595f56181b073d564a5f94510d4a40dab39cc6543e6a2c9825f785a48ddaf51",
+    arm: "5c66fdc6adb6e7aa383b0979b1228c7c7b8d0b7d60989a13993ee8043b756883"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-6-6.rb
+++ b/Casks/terraform-1-6-6.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-6-6" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.6.6"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "33376343c7e0279b674c1c8b8a31dc3174ac09dd796d32651cc5e3b98f220436",
+    arm: "01e608fc04cf54869db687a212d60f3dc3d5c828298514857f9e29f8ac1354a9"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-0-alpha20231025.rb
+++ b/Casks/terraform-1-7-0-alpha20231025.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-0-alpha20231025" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.0-alpha20231025"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "53d8dd65dd17f5f6294e4f6defc70c336cd2363e2ddf8edde16a626dbdc7cf23",
+    arm: "b6be241258c93a2dfd28a09535c6a5da79b6df1d26a7a2d0738239f128e724a5"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-0-alpha20231108.rb
+++ b/Casks/terraform-1-7-0-alpha20231108.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-0-alpha20231108" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.0-alpha20231108"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "68a916fa04ca6a43cfcb803edd5703d2349b74481f27bd7777d6885a6abb721f",
+    arm: "772415b52f31d9af114aa50a5a9c3ff0261f74048cc581562c3fa1e931da405f"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-0-alpha20231130.rb
+++ b/Casks/terraform-1-7-0-alpha20231130.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-0-alpha20231130" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.0-alpha20231130"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "c7e399552d7490df1472e97a72483b030fba9c96a65c42566fb6009483768c8f",
+    arm: "ad7bef2149b8bf8d695aa5fda3f5bffa38c71fdb4ed5c4243f2f826fc6554219"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-0-beta1.rb
+++ b/Casks/terraform-1-7-0-beta1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.0-beta1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "c396b2f31051a0dac6850b3c417eea1ded208c6c46baac16469c48624352a2a0",
+    arm: "4960ff477109074c6ad7392435422bd29bbbb1b21ef3718979cda2440e9835bf"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-0-beta2.rb
+++ b/Casks/terraform-1-7-0-beta2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-0-beta2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.0-beta2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "7c09244a80dba64d5f62c75b6bb006be9e8b71f63a9c729e69cf8ae2b5ed64c2",
+    arm: "4975da1056a0f5f41499b7f080bf8ceed5939a8be8d373a74fdf96e7c06e0d92"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-0-rc1.rb
+++ b/Casks/terraform-1-7-0-rc1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-0-rc1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.0-rc1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "9e043db605dc385483e8a9348d4dd66d3bae3bd470fb9af775f401daffecdc45",
+    arm: "008bf91d5f611b9f58847c927cc8fae130d272af0288a2d2352be523084118e4"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-0-rc2.rb
+++ b/Casks/terraform-1-7-0-rc2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-0-rc2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.0-rc2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "eb63e7f64cc108897b7429866c3f94c966fec007038f7355728218cd3ef86739",
+    arm: "645b8da5c5cbf8b9a2ce195e7a419ee7c6850d321df9798aea770b1f614408c6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-0.rb
+++ b/Casks/terraform-1-7-0.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-0" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.0"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "621a2ef8d0ca4e5bb613632983b6b2cd53d542978117df779ac363422ce6802d",
+    arm: "7c23ffbeba15c38ce547e62ba4ffbb2c3620cf5b38bf9fa8037cfa81544d1150"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-1.rb
+++ b/Casks/terraform-1-7-1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "db05d272f5070eacab70fc14a091f5a9e6c734423794901d79ffd3c612933235",
+    arm: "d4ee3a591d022fda26e1eb153a25e38ee4f0311720719c329ed38cf2ae8c14e5"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-2.rb
+++ b/Casks/terraform-1-7-2.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-2" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.2"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "dad2fd54b3dda89b39978dcd27c8c62e13010efdc0507a04b6ad57257b57085e",
+    arm: "d8c7b8b1aa7f0b38a2e437d9c9e4e632b2b258e3bf48bb6de4626f3b0afea5e4"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-3.rb
+++ b/Casks/terraform-1-7-3.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-3" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.3"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "4787f5a422439d3b277a889b159981e88049f48bcf9e41e70481620567a7fd9c",
+    arm: "85cddfd303c45989f0948a70ae03bb30f66c6e6106383697fe85ccd739137ca6"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-4.rb
+++ b/Casks/terraform-1-7-4.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-4" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.4"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "fcf35c8b1d3f46fb84f688312ef5f829081d2d56c10444b9f6e290e21e68871c",
+    arm: "3f25268a5d7677cc89d39a505362979acfb02f19ddb965d7ec0b33a6d9e64075"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-7-5.rb
+++ b/Casks/terraform-1-7-5.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-7-5" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.7.5"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "0eaf64e28f82e2defd06f7a6f3187d8cea03d5d9fcd2af54f549a6c32d6833f7",
+    arm: "99c4d4feafb0183af2f7fbe07beeea6f83e5f5a29ae29fee3168b6810e37ff98"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-8-0-alpha20240131.rb
+++ b/Casks/terraform-1-8-0-alpha20240131.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-8-0-alpha20240131" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.8.0-alpha20240131"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "f5ff6ea01a93b45f3cc884c9d48d5e26c7933c0e8d176f4fe4ccc2892a096563",
+    arm: "7eb7615bc6f3acc3f664a817cbf975374372249286672bc1b857788952fb66de"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-8-0-alpha20240214.rb
+++ b/Casks/terraform-1-8-0-alpha20240214.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-8-0-alpha20240214" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.8.0-alpha20240214"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "b8093f8770eba6e22879941d59f020bbf315ac73b7ee8409820fc66b2e7fffe7",
+    arm: "47c6f59a38c3f53eb4d2e239dac8528507fd75cb6f98fa2bdedb47eb6b0c081c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-8-0-alpha20240216.rb
+++ b/Casks/terraform-1-8-0-alpha20240216.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-8-0-alpha20240216" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.8.0-alpha20240216"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "caf152a2291ab4a77859c563f4fc1da2924ab2af65c0c9c37f24ef5eccbfe883",
+    arm: "928fc218cab93d8e937ccc6380c8382b1e8d0f851b10d9502cf25eb087a13d3c"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-8-0-alpha20240228.rb
+++ b/Casks/terraform-1-8-0-alpha20240228.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-8-0-alpha20240228" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.8.0-alpha20240228"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "1c6b38f3e77a79bd285e7f7c7e800f91b58b5e40b6d736422ecd021ed281799c",
+    arm: "6251ae32bb0a8a98464e2eb2b43e880b59151ca8db438bef5e10a4785c211074"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/Casks/terraform-1-8-0-beta1.rb
+++ b/Casks/terraform-1-8-0-beta1.rb
@@ -1,0 +1,19 @@
+cask "terraform-1-8-0-beta1" do
+  name "Terraform"
+  homepage "https://www.terraform.io/"
+
+  version "1.8.0-beta1"
+
+  arch intel: "amd64", arm: "arm64"
+
+  sha256 intel: "a975d14026fe2b36bd0ab09c2cae113d2d2a58173151387981e6ce787094b91c",
+    arm: "8459f7e2ac80844ac7a78b4b667357e47a713eccddf8782d7428e91bf6c220f0"
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
+end

--- a/_cask_template.erb
+++ b/_cask_template.erb
@@ -1,16 +1,23 @@
-cask "terraform-<%= version %>" do
-  version "<%= version %>"
-
+cask "terraform-<%= cask_version %>" do
   name "Terraform"
   homepage "https://www.terraform.io/"
 
-  case Hardware::CPU.arch
-<% cask_builds.each do |build| -%>
-  when <%= build.cask_arch.inspect %>
-    url "<%= build.url %>"
-    sha256 "<%= build.sha256 %>"
-<% end -%>
-  end
+  version "<%= version %>"
 
-  depends_on arch: <%= cask_archs %>
+  <%- if cask_builds.length == 1 -%>
+  arch = <%= cask_builds.first.arch.inspect %>
+  sha256 <%= cask_builds.first.sha256.inspect %>
+  <%- else -%>
+  arch <%= cask_builds.map { |build| "#{build.cask_arch}: #{build.arch.inspect}" }.join(", ") %>
+
+  sha256 <%= cask_builds.map { |build| "#{build.cask_arch}: #{build.sha256.inspect}" }.join(",\n    ") %>
+  <%- end -%>
+
+  url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_#{arch}.zip",
+    verified: "releases.hashicorp.com/terraform"
+
+
+  # Binaries not installed as multiple versions are expected to coexist.
+  # Normally the wanted version is selected with `chtf`.
+  stage_only true
 end

--- a/scripts/add_new_terraform_casks
+++ b/scripts/add_new_terraform_casks
@@ -12,7 +12,10 @@ CASK_DIR = ENV['CASK_DIR'] || 'Casks'
 CASK_TEMPLATE = ENV['CASK_TEMPLATE'] || '_cask_template.erb'
 
 CASK_OS = 'darwin'
-CASK_ARCHS = %i[x86_64 arm64].freeze
+CASK_ARCHS = {
+  'amd64' => 'intel',
+  'arm64' => 'arm'
+}.freeze
 
 RELEASES_BASE_URL = 'https://releases.hashicorp.com/terraform'
 
@@ -67,6 +70,10 @@ class TerraformReleases
       super
     end
 
+    def cask_version
+      Casks.cask_version(version)
+    end
+
     # Builds suitable for Casks
     def cask_builds
       @cask_builds ||= builds.select(&:cask_arch?).tap do |builds|
@@ -92,11 +99,11 @@ class TerraformReleases
     end
 
     def cask_arch?
-      os == CASK_OS && CASK_ARCHS.include?(cask_arch)
+      os == CASK_OS && CASK_ARCHS.keys.include?(arch)
     end
 
     def cask_arch
-      arch == 'amd64' ? :x86_64 : arch.to_sym
+      CASK_ARCHS[arch]
     end
 
     def sha256
@@ -166,18 +173,23 @@ end
 
 # Terraform Casks in this repository
 class Casks
+  def self.cask_version(version)
+      version.downcase.gsub(/[^@a-z0-9]+/, '-')
+  end
+
   def include?(version)
-    versions.include?(version)
+    versions.include?(Casks.cask_version(version))
   end
 
   def add(release)
-    cask_file = File.join(CASK_DIR, "terraform-#{release.version}.rb")
+    cask_file = File.join(CASK_DIR, "terraform-#{release.cask_version}.rb")
     IO.write(cask_file, template.result(release.binding))
   end
 
   def versions
     @versions ||= Dir.glob(File.join(CASK_DIR, 'terraform-*.rb')).map do |file|
-      File.basename(file, '.rb').sub(/^terraform-/, '')
+      v = File.basename(file, '.rb').sub(/^terraform-/, '')
+      Casks.cask_version(v)
     end
   end
 


### PR DESCRIPTION
Seems that Homebrew started to enforce that audit passes, at least for the Cask name only including allowed characters.

So rename the Casks, and fix the DSL.

This addresses #217, but `chtf` changes are still needed to support new Cask names. And this also fixes the issue for installing old intel version to arm Macs.

For now, leave the old Casks still in the repo to possibly support older Brew (and chtf) versions.