### PR TITLE
Update `chtf`, and the references to new owner

### DIFF
--- a/.github/workflows/add-new-casks.yml
+++ b/.github/workflows/add-new-casks.yml
@@ -8,7 +8,7 @@ jobs:
   add_new_casks:
     name: Add New Terraform Casks
     # Only run on the main repo
-    if: github.repository == 'Yleisradio/homebrew-terraforms'
+    if: github.repository == 'tmatilai/homebrew-terraforms'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/Formula/chtf.rb
+++ b/Formula/chtf.rb
@@ -1,12 +1,12 @@
 class Chtf < Formula
   desc "Terraform version switcher"
-  homepage "https://github.com/Yleisradio/chtf#readme"
+  homepage "https://github.com/tmatilai/chtf#readme"
 
-  url "https://github.com/Yleisradio/chtf/archive/refs/tags/v2.2.2.tar.gz"
-  sha256 "00d797dccf0aff03034be2dc75698a3f24c5ba56363202c9a32b31e3184a0686"
+  url "https://github.com/tmatilai/chtf/archive/refs/tags/v2.3.0.tar.gz"
+  sha256 "d44606fe55ba2903f00b1f93ba411d4e06aa02978a577d8491e477c28a8a47bc"
   license "MIT"
 
-  head "https://github.com/Yleisradio/chtf.git"
+  head "https://github.com/tmatilai/chtf.git"
 
   option "without-completions", "Disable shell command completions"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2016-2021 Yleisradio Oy
-Copyright (c) 2020-2024 Teemu Matilainen
+Copyright (c) 2020-2025 Teemu Matilainen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 This repository includes [Homebrew](https://brew.sh/) Casks to install multiple (or even all!) Terraform versions at the same time. It also includes Homebrew Formula for [chtf][], a Terraform version switcher.
 
-**NOTE**: The `chtf` tool has been extracted to its own repository: [https://github.com/Yleisradio/chtf][chtf]. It can still be installed via this Tap and used as before. But now it also supports systems without Homebrew, also for auto-install.
+**NOTE**: The `chtf` tool has been extracted to its own repository: [https://github.com/tmatilai/chtf][chtf]. It can still be installed via this Tap and used as before. But now it also supports systems without Homebrew, also for auto-install.
 
-[chtf]: https://github.com/Yleisradio/chtf
+[chtf]: https://github.com/tmatilai/chtf
 
 ## Usage
 
 Tap this repository:
 
-    brew tap yleisradio/terraforms
+    brew tap tmatilai/terraforms
 
-Install the [`chtf`](https://github.com/Yleisradio/chtf) helper:
+Install the [`chtf`](https://github.com/tmatilai/chtf) helper:
 
     brew install chtf
 
@@ -36,6 +36,6 @@ You can also just install a specific Terraform version (but you'll need to use `
 
 ## Contributing
 
-Bug reports, pull requests, and other contributions are welcome on GitHub at https://github.com/Yleisradio/homebrew-terraforms.
+Bug reports, pull requests, and other contributions are welcome on GitHub at https://github.com/tmatilai/homebrew-terraforms.
 
 This project is intended to be a safe, welcoming space for collaboration. By participating in this project you agree to abide by the terms of [Contributor Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Upgrade the `chtf` formula to version 2.3.0 and update all links and references to the new GitHub owner, `tmatilai`.